### PR TITLE
btcwallet: lfu block cache

### DIFF
--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -21,6 +21,7 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/lightninglabs/neutrino/cache/lru"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -32,6 +33,10 @@ const (
 	// UnconfirmedHeight is the special case end height that is used to
 	// obtain unconfirmed transactions from ListTransactionDetails.
 	UnconfirmedHeight int32 = -1
+
+	// defaultBlockCacheSize is the default maximum number of blocks that
+	// the LFU block cache can hold.
+	defaultBlockCacheSize = 5
 )
 
 var (
@@ -57,6 +62,9 @@ type BtcWallet struct {
 	wallet *base.Wallet
 
 	chain chain.Interface
+
+	// blockCache is a LRU block cache.
+	blockCache *lru.Cache
 
 	db walletdb.DB
 
@@ -133,6 +141,7 @@ func New(cfg Config) (*BtcWallet, error) {
 		chain:         cfg.ChainSource,
 		netParams:     cfg.NetParams,
 		chainKeyScope: chainKeyScope,
+		blockCache:    lru.NewCache(defaultBlockCacheSize),
 	}, nil
 }
 

--- a/lnwallet/btcwallet/btcwallet_test.go
+++ b/lnwallet/btcwallet/btcwallet_test.go
@@ -1,0 +1,95 @@
+package btcwallet
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/neutrino/cache"
+	"github.com/lightninglabs/neutrino/cache/lru"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetBlock tests that the block cache works correctly as a LFU block
+// cache for the given max capacity.
+func TestGetBlock(t *testing.T) {
+	// A new cache is set up with a capacity of 2 blocks
+	bc := lru.NewCache(2)
+	mc := newMockChain()
+
+	bw := &BtcWallet{
+		chain:      mc,
+		blockCache: bc,
+	}
+
+	block1 := &wire.MsgBlock{Header: wire.BlockHeader{Nonce: 1}}
+	block2 := &wire.MsgBlock{Header: wire.BlockHeader{Nonce: 2}}
+	block3 := &wire.MsgBlock{Header: wire.BlockHeader{Nonce: 3}}
+
+	blockhash1 := block1.BlockHash()
+	blockhash2 := block2.BlockHash()
+	blockhash3 := block3.BlockHash()
+
+	mc.addBlock(&wire.MsgBlock{}, 1)
+	mc.addBlock(&wire.MsgBlock{}, 2)
+	mc.addBlock(&wire.MsgBlock{}, 3)
+
+	// We expect the initial cache to be empty
+	require.Equal(t, 0, bc.Len())
+
+	// After calling GetBlock for block1, it is expected that the cache
+	// will have a size of 1 and will contain block1. One chain backends
+	// call is expected to fetch the block.
+	_, err := bw.GetBlock(&blockhash1)
+	require.NoError(t, err)
+	require.Equal(t, 1, bc.Len())
+	require.Equal(t, 1, mc.chainCallCount)
+	mc.resetChainCallCount()
+
+	_, err = bc.Get(blockhash1)
+	require.NoError(t, err)
+
+	// After calling GetBlock for block2, it is expected that the cache
+	// will have a size of 2 and will contain both block1 and block2.
+	// One chain backends call is expected to fetch the block.
+	_, err = bw.GetBlock(&blockhash2)
+	require.NoError(t, err)
+	require.Equal(t, 2, bc.Len())
+	require.Equal(t, 1, mc.chainCallCount)
+	mc.resetChainCallCount()
+
+	_, err = bc.Get(blockhash1)
+	require.NoError(t, err)
+
+	_, err = bc.Get(blockhash2)
+	require.NoError(t, err)
+
+	// GetBlock is called again for block1 to make block2 the LFU block.
+	// No call to the chain backend is expected since block 1 is already
+	// in the cache.
+	_, err = bw.GetBlock(&blockhash1)
+	require.NoError(t, err)
+	require.Equal(t, 2, bc.Len())
+	require.Equal(t, 0, mc.chainCallCount)
+	mc.resetChainCallCount()
+
+	// Since the cache is now at its max capacity, it is expected that when
+	// getBlock is called for a new block then the LFU block will be
+	// evicted. It is expected that block2 will be evicted. After calling
+	// Getblock for block3, it is expected that the cache will have a
+	// length of 2 and will contain block 1 and 3.
+	_, err = bw.GetBlock(&blockhash3)
+	require.NoError(t, err)
+	require.Equal(t, 2, bc.Len())
+	require.Equal(t, 1, mc.chainCallCount)
+	mc.resetChainCallCount()
+
+	_, err = bc.Get(blockhash1)
+	require.NoError(t, err)
+
+	_, err = bc.Get(blockhash2)
+	require.True(t, errors.Is(err, cache.ErrElementNotFound))
+
+	_, err = bc.Get(blockhash3)
+	require.NoError(t, err)
+}

--- a/lnwallet/btcwallet/mock_chain.go
+++ b/lnwallet/btcwallet/mock_chain.go
@@ -1,0 +1,161 @@
+package btcwallet
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+)
+
+type mockChainClient struct {
+	blocks         map[chainhash.Hash]*wire.MsgBlock
+	chainCallCount int
+
+	sync.RWMutex
+}
+
+func newMockChain() *mockChainClient {
+	return &mockChainClient{
+		blocks: make(map[chainhash.Hash]*wire.MsgBlock),
+	}
+}
+
+var _ chain.Interface = (*mockChainClient)(nil)
+
+func (m *mockChainClient) resetChainCallCount() {
+	m.RLock()
+	defer m.RUnlock()
+
+	m.chainCallCount = 0
+}
+
+func (m *mockChainClient) Start() error {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return nil
+}
+
+func (m *mockChainClient) Stop() {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+}
+
+func (m *mockChainClient) WaitForShutdown() {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+}
+
+func (m *mockChainClient) GetBestBlock() (*chainhash.Hash, int32, error) {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return nil, 0, nil
+}
+
+func (m *mockChainClient) addBlock(block *wire.MsgBlock, nonce uint32) {
+	m.Lock()
+	block.Header.Nonce = nonce
+	hash := block.Header.BlockHash()
+	m.blocks[hash] = block
+	m.Unlock()
+}
+func (m *mockChainClient) GetBlock(blockHash *chainhash.Hash) (*wire.MsgBlock, error) {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+
+	block, ok := m.blocks[*blockHash]
+	if !ok {
+		return nil, fmt.Errorf("block not found")
+	}
+
+	return block, nil
+}
+
+func (m *mockChainClient) GetBlockHash(int64) (*chainhash.Hash, error) {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return nil, nil
+}
+
+func (m *mockChainClient) GetBlockHeader(*chainhash.Hash) (*wire.BlockHeader,
+	error) {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return nil, nil
+}
+
+func (m *mockChainClient) IsCurrent() bool {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return false
+}
+
+func (m *mockChainClient) FilterBlocks(*chain.FilterBlocksRequest) (
+	*chain.FilterBlocksResponse, error) {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return nil, nil
+}
+
+func (m *mockChainClient) BlockStamp() (*waddrmgr.BlockStamp, error) {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return nil, nil
+}
+
+func (m *mockChainClient) SendRawTransaction(*wire.MsgTx, bool) (
+	*chainhash.Hash, error) {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return nil, nil
+}
+
+func (m *mockChainClient) Rescan(*chainhash.Hash, []btcutil.Address,
+	map[wire.OutPoint]btcutil.Address) error {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return nil
+}
+
+func (m *mockChainClient) NotifyReceived([]btcutil.Address) error {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return nil
+}
+
+func (m *mockChainClient) NotifyBlocks() error {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return nil
+}
+
+func (m *mockChainClient) Notifications() <-chan interface{} {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return nil
+}
+
+func (m *mockChainClient) BackEnd() string {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+	return "mock"
+}


### PR DESCRIPTION
This commit adds a LFU blockcache to btcwallet for the purpose of saving in
bandwidth consumption.
