### PR TITLE
rpcserver+lnrpc: make Subscribe RPCs context aware

### DIFF
--- a/lnrpc/invoicesrpc/invoices_server.go
+++ b/lnrpc/invoicesrpc/invoices_server.go
@@ -247,6 +247,10 @@ func (s *Server) SubscribeSingleInvoice(req *SubscribeSingleInvoiceRequest,
 				return err
 			}
 
+		case <-updateStream.Context().Done():
+			log.Debugf("invoice event stream cancelled")
+			return updateStream.Context().Err()
+
 		case <-s.quit:
 			return nil
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2720,6 +2720,11 @@ func (r *rpcServer) SubscribePeerEvents(req *lnrpc.PeerEventSubscription,
 			if err := eventStream.Send(event); err != nil {
 				return err
 			}
+
+		case <-eventStream.Context().Done():
+			rpcsLog.Info("peer events stream cancelled")
+			return eventStream.Context().Err()
+
 		case <-r.quit:
 			return nil
 		}
@@ -3943,6 +3948,11 @@ func (r *rpcServer) SubscribeChannelEvents(req *lnrpc.ChannelEventSubscription,
 			if err := updateStream.Send(update); err != nil {
 				return err
 			}
+
+		case <-updateStream.Context().Done():
+			rpcsLog.Info("channel events stream cancelled")
+			return updateStream.Context().Err()
+
 		case <-r.quit:
 			return nil
 		}
@@ -4856,6 +4866,10 @@ func (r *rpcServer) SubscribeInvoices(req *lnrpc.InvoiceSubscription,
 				return err
 			}
 
+		case <-updateStream.Context().Done():
+			rpcsLog.Info("invoices event stream cancelled")
+			return updateStream.Context().Err()
+
 		case <-r.quit:
 			return nil
 		}
@@ -4912,6 +4926,10 @@ func (r *rpcServer) SubscribeTransactions(req *lnrpc.GetTransactionsRequest,
 			if err := updateStream.Send(detail); err != nil {
 				return err
 			}
+
+		case <-updateStream.Context().Done():
+			rpcsLog.Info("transaction event stream cancelled")
+			return updateStream.Context().Err()
 
 		case <-r.quit:
 			return nil
@@ -5433,6 +5451,10 @@ func (r *rpcServer) SubscribeChannelGraph(req *lnrpc.GraphTopologySubscription,
 			if err := updateStream.Send(graphUpdate); err != nil {
 				return err
 			}
+
+		case <-updateStream.Context().Done():
+			rpcsLog.Info("channel graph event stream cancelled")
+			return updateStream.Context().Err()
 
 		// The server is quitting, so we'll exit immediately. Returning
 		// nil will close the clients read end of the stream.
@@ -6345,6 +6367,11 @@ func (r *rpcServer) SubscribeChannelBackups(req *lnrpc.ChannelBackupSubscription
 			if err != nil {
 				return err
 			}
+
+		case <-updateStream.Context().Done():
+			rpcsLog.Info("channel backup event stream " +
+				"cancelled")
+			return updateStream.Context().Err()
 
 		case <-r.quit:
 			return nil


### PR DESCRIPTION
This commit makes all the Subscribe RCP's context aware so that they
stop executing when the request context is cancelled.