### PR TITLE
peer: return from pingHandler if error

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2016,6 +2016,7 @@ func (p *Brontide) pingHandler() {
 	if err != nil {
 		peerLog.Errorf("unable to establish block epoch "+
 			"subscription: %v", err)
+		return
 	}
 
 	var (


### PR DESCRIPTION
This commit adds a missing return statement to pingHandler. This
prevents a nil pointer dereference panic from happening if an error is
returned from RegisterBlockEpochNtfn.

Found this after getting this travis job failure:

```
=== CONT  TestLightningNetworkDaemon
    test_harness.go:118: lnd finished with error (stderr):
        exit status 2
        panic: runtime error: invalid memory address or nil pointer dereference
        [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xae1550]
        
        goroutine 1000 [running]:
        github.com/lightningnetwork/lnd/peer.(*Brontide).pingHandler(0x3939200)
        	/home/travis/gopath/src/github.com/lightningnetwork/lnd/peer/brontide.go:2034 +0xc8
        created by github.com/lightningnetwork/lnd/peer.(*Brontide).Start
        	/home/travis/gopath/src/github.com/lightningnetwork/lnd/peer/brontide.go:570 +0x618
        
    test_harness.go:118: lnd finished with error (stderr):
        exit status 2
        panic: runtime error: invalid memory address or nil pointer dereference
        [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xae1550]
        
        goroutine 743 [running]:
        github.com/lightningnetwork/lnd/peer.(*Brontide).pingHandler(0x2d3ca00)
        	/home/travis/gopath/src/github.com/lightningnetwork/lnd/peer/brontide.go:2034 +0xc8
        created by github.com/lightningnetwork/lnd/peer.(*Brontide).Start
        	/home/travis/gopath/src/github.com/lightningnetwork/lnd/peer/brontide.go:570 +0x618
```