### PR TITLE
multi: configurable anchor conf target

### DIFF
--- a/config.go
+++ b/config.go
@@ -105,6 +105,10 @@ const (
 	// initiated the channel closure.
 	defaultCoopCloseTargetConfs = 6
 
+	// defaultAnchorsCommitmentConfTarget is the default confirmation target
+	// used to estimate the fee to use for anchor commitments.
+	defaultAnchorsCommitmentConfTarget = 6
+
 	// defaultBlockCacheSize is the size (in bytes) of blocks that will be
 	// keep in memory if no size is specified.
 	defaultBlockCacheSize uint64 = 20 * 1024 * 1024 // 20 MB
@@ -348,6 +352,8 @@ type Config struct {
 
 	MaxCommitFeeRateAnchors uint64 `long:"max-commit-fee-rate-anchors" description:"The maximum fee rate in sat/vbyte that will be used for commitments of channels of the anchors type. Must be large enough to ensure transaction propagation"`
 
+	AnchorsCommitConfTarget uint32 `long:"anchors-commit-conf-target" description:"The target number of blocks to be used to estimate the fee to use for anchor commitments"`
+
 	DryRunMigration bool `long:"dry-run-migration" description:"If true, lnd will abort committing a migration if it would otherwise have been successful. This leaves the database unmodified, and still compatible with the previously active version of lnd."`
 
 	net tor.Net
@@ -569,6 +575,7 @@ func DefaultConfig() Config {
 		MaxOutgoingCltvExpiry:   htlcswitch.DefaultMaxOutgoingCltvExpiry,
 		MaxChannelFeeAllocation: htlcswitch.DefaultMaxLinkFeeAllocation,
 		MaxCommitFeeRateAnchors: lnwallet.DefaultAnchorsCommitMaxFeeRateSatPerVByte,
+		AnchorsCommitConfTarget: defaultAnchorsCommitmentConfTarget,
 		DustThreshold:           uint64(htlcswitch.DefaultDustThreshold.ToSatoshis()),
 		LogWriter:               build.NewRotatingLogWriter(),
 		DB:                      lncfg.DefaultDB(),

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -303,6 +303,10 @@ type Config struct {
 	// initiator for anchor channel commitments.
 	MaxAnchorsCommitFeeRate chainfee.SatPerKWeight
 
+	// AnchorsCommitConfTarget is the confirmation target used to determine
+	// the fee to use for anchor commitments.
+	AnchorsCommitConfTarget uint32
+
 	// CoopCloseTargetConfs is the confirmation target that will be used
 	// to estimate the fee rate to use during a cooperative channel
 	// closure initiated by the remote peer.
@@ -851,6 +855,7 @@ func (p *Brontide) addLink(chanPoint *wire.OutPoint,
 		MaxOutgoingCltvExpiry:   p.cfg.MaxOutgoingCltvExpiry,
 		MaxFeeAllocation:        p.cfg.MaxChannelFeeAllocation,
 		MaxAnchorsCommitFeeRate: p.cfg.MaxAnchorsCommitFeeRate,
+		AnchorsCommitConfTarget: p.cfg.AnchorsCommitConfTarget,
 		NotifyActiveLink:        p.cfg.ChannelNotifier.NotifyActiveLinkEvent,
 		NotifyActiveChannel:     p.cfg.ChannelNotifier.NotifyActiveChannelEvent,
 		NotifyInactiveChannel:   p.cfg.ChannelNotifier.NotifyInactiveChannelEvent,

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -365,6 +365,10 @@
 ; propagation (default: 10)
 ; max-commit-fee-rate-anchors=5
 
+; The confirmation target to be used to estimate the fee to be used for anchor
+; commitment transactions. (default: 6)
+; anchors-commit-conf-target=10
+
 ; A threshold defining the maximum amount of dust a given channel can have
 ; after which forwarding and sending dust HTLC's to and from the channel will
 ; fail. This amount is expressed in satoshis. (default: 500000)

--- a/server.go
+++ b/server.go
@@ -3434,10 +3434,11 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		CoopCloseTargetConfs:    s.cfg.CoopCloseTargetConfs,
 		MaxAnchorsCommitFeeRate: chainfee.SatPerKVByte(
 			s.cfg.MaxCommitFeeRateAnchors * 1000).FeePerKWeight(),
-		ChannelCommitInterval:  s.cfg.ChannelCommitInterval,
-		ChannelCommitBatchSize: s.cfg.ChannelCommitBatchSize,
-		HandleCustomMessage:    s.handleCustomMessage,
-		Quit:                   s.quit,
+		AnchorsCommitConfTarget: s.cfg.AnchorsCommitConfTarget,
+		ChannelCommitInterval:   s.cfg.ChannelCommitInterval,
+		ChannelCommitBatchSize:  s.cfg.ChannelCommitBatchSize,
+		HandleCustomMessage:     s.handleCustomMessage,
+		Quit:                    s.quit,
 	}
 
 	copy(pCfg.PubKeyBytes[:], peerAddr.IdentityKey.SerializeCompressed())


### PR DESCRIPTION
In this commit, a new config option is added so that users can set the
confirmation target to be used for anchor commitments. The default value
is set to 6. Before this commit, a conf target of 3 was used.
