### PR TITLE
lnwire: ignore unknow addrs in NodeAnnouncement

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -105,6 +105,9 @@ then watch it on chain. Taproot script spends are also supported through the
 * [Fixed incorrect PSBT de-serialization for transactions with no
   inputs](https://github.com/lightningnetwork/lnd/pull/6428).
 
+* [Ignore addresses with unknown types in NodeAnnouncements](
+  https://github.com/lightningnetwork/lnd/pull/6435)
+
 ## Routing
 
 * [Add a new `time_pref` parameter to the QueryRoutes and SendPayment APIs](https://github.com/lightningnetwork/lnd/pull/6024) that

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -804,7 +804,17 @@ func ReadElement(r io.Reader, element interface{}) error {
 				addrBytesRead += aType.AddrLen()
 
 			default:
-				return &ErrUnknownAddrType{aType}
+				// If we don't understand this address type,
+				// we just ignore it along with the remaining
+				// address bytes.
+				garbage := make([]byte, addrsLen-addrBytesRead)
+				_, err := io.ReadFull(addrBuf, garbage[:])
+				if err != nil {
+					return err
+				}
+
+				addrBytesRead = addrsLen
+				continue
 			}
 
 			addresses = append(addresses, address)

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -13,6 +13,8 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcutil"
@@ -224,6 +226,51 @@ func TestChanUpdateChanFlags(t *testing.T) {
 				test.expected, toStr)
 		}
 	}
+}
+
+// TestDecodeUnknownAddressType shows that an unknown address type is currently
+// incorrectly dealt with.
+func TestDecodeUnknownAddressType(t *testing.T) {
+	// First, we'll encode all the addresses into an intermediate
+	// buffer. We need to do this in order to compute the total
+	// length of the addresses.
+	addrBuf := bytes.NewBuffer(make([]byte, 0, MaxMsgBody))
+
+	// Add a normal, clearnet address.
+	tcpAddr := &net.TCPAddr{
+		IP:   net.IP{127, 0, 0, 1},
+		Port: 8080,
+	}
+
+	err := WriteTCPAddr(addrBuf, tcpAddr)
+	require.NoError(t, err)
+
+	// Add an onion address.
+	onionAddr := &tor.OnionAddr{
+		OnionService: "abcdefghijklmnop.onion",
+		Port:         9065,
+	}
+
+	err = WriteOnionAddr(addrBuf, onionAddr)
+	require.NoError(t, err)
+
+	// Now add an address with an unknown type.
+	var newAddrType addressType = math.MaxUint8
+	data := make([]byte, 0, 16)
+	data = append(data, uint8(newAddrType))
+	_, err = addrBuf.Write(data)
+	require.NoError(t, err)
+
+	// Now that we have all the addresses, we can append the length.
+	buffer := bytes.NewBuffer(make([]byte, 0, MaxMsgBody))
+	err = writeDataWithLength(buffer, addrBuf.Bytes())
+	require.NoError(t, err)
+
+	// Now we attempt to parse the bytes and we assert that we get an error.
+	var addrs []net.Addr
+	err = ReadElement(buffer, &addrs)
+	require.Error(t, err)
+	require.IsType(t, err, &ErrUnknownAddrType{})
 }
 
 func TestMaxOutPointIndex(t *testing.T) {

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -228,8 +228,8 @@ func TestChanUpdateChanFlags(t *testing.T) {
 	}
 }
 
-// TestDecodeUnknownAddressType shows that an unknown address type is currently
-// incorrectly dealt with.
+// TestDecodeUnknownAddressType tests that an unknown address type is correctly
+// ignored and skipped
 func TestDecodeUnknownAddressType(t *testing.T) {
 	// First, we'll encode all the addresses into an intermediate
 	// buffer. We need to do this in order to compute the total
@@ -266,11 +266,15 @@ func TestDecodeUnknownAddressType(t *testing.T) {
 	err = writeDataWithLength(buffer, addrBuf.Bytes())
 	require.NoError(t, err)
 
-	// Now we attempt to parse the bytes and we assert that we get an error.
+	// Now we attempt to parse the bytes and we check that we were still
+	// able to get the two addresses with they types that we are aware of.
 	var addrs []net.Addr
 	err = ReadElement(buffer, &addrs)
-	require.Error(t, err)
-	require.IsType(t, err, &ErrUnknownAddrType{})
+	require.NoError(t, err)
+
+	require.Len(t, addrs, 2)
+	require.Equal(t, tcpAddr.String(), addrs[0].String())
+	require.Equal(t, onionAddr.String(), addrs[1].String())
 }
 
 func TestMaxOutPointIndex(t *testing.T) {


### PR DESCRIPTION
Ignore addresses with unknow types in NodeAnnouncement.

## Change Description
Description of change / link to associated issue.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.