### PR TITLE
delete sessions

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -148,6 +148,10 @@ https://github.com/lightningnetwork/lnd/pull/6963/)
 * [Store AckedUpdates in a more compact 
   way](https://github.com/lightningnetwork/lnd/pull/7055)
 
+* [Clean up sessions once all channels for which they have updates for are
+  closed. Also start sending the `DeleteSession` message to the 
+  tower.](https://github.com/lightningnetwork/lnd/pull/7069)
+
 ### Tooling and documentation
 
 * [The `golangci-lint` tool was updated to

--- a/server.go
+++ b/server.go
@@ -1501,6 +1501,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		}
 
 		s.towerClient, err = wtclient.New(&wtclient.Config{
+			ChainNotifier:   s.cc.ChainNotifier,
 			IsChannelClosed: isChanClosed,
 			SubscribeChannelEvents: func() (subscribe.Subscription, error) {
 				return s.channelNotifier.SubscribeChannelEvents()
@@ -1528,6 +1529,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			blob.Type(blob.FlagAnchorChannel)
 
 		s.anchorTowerClient, err = wtclient.New(&wtclient.Config{
+			ChainNotifier:   s.cc.ChainNotifier,
 			IsChannelClosed: isChanClosed,
 			SubscribeChannelEvents: func() (subscribe.Subscription, error) {
 				return s.channelNotifier.SubscribeChannelEvents()

--- a/watchtower/wtclient/candidate_iterator.go
+++ b/watchtower/wtclient/candidate_iterator.go
@@ -29,6 +29,10 @@ type TowerCandidateIterator interface {
 	// candidates available as long as they remain in the set.
 	Reset() error
 
+	// GetTower gets the tower with the given ID from the iterator. If no
+	// such tower is found then ErrTowerNotInIterator is returned.
+	GetTower(id wtdb.TowerID) (*Tower, error)
+
 	// Next returns the next candidate tower. The iterator is not required
 	// to return results in any particular order.  If no more candidates are
 	// available, ErrTowerCandidatesExhausted is returned.
@@ -74,6 +78,20 @@ func (t *towerListIterator) Reset() error {
 	t.nextCandidate = t.queue.Front()
 
 	return nil
+}
+
+// GetTower gets the tower with the given ID from the iterator. If no such tower
+// is found then ErrTowerNotInIterator is returned.
+func (t *towerListIterator) GetTower(id wtdb.TowerID) (*Tower, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	tower, ok := t.candidates[id]
+	if !ok {
+		return nil, ErrTowerNotInIterator
+	}
+
+	return tower, nil
 }
 
 // Next returns the next candidate tower. This iterator will always return

--- a/watchtower/wtclient/candidate_iterator_test.go
+++ b/watchtower/wtclient/candidate_iterator_test.go
@@ -83,9 +83,15 @@ func assertNextCandidate(t *testing.T, i TowerCandidateIterator, c *Tower) {
 
 	tower, err := i.Next()
 	require.NoError(t, err)
-	require.True(t, tower.IdentityKey.IsEqual(c.IdentityKey))
-	require.Equal(t, tower.ID, c.ID)
-	require.Equal(t, tower.Addresses.GetAll(), c.Addresses.GetAll())
+	assertTowersEqual(t, c, tower)
+}
+
+func assertTowersEqual(t *testing.T, expected, actual *Tower) {
+	t.Helper()
+
+	require.True(t, expected.IdentityKey.IsEqual(actual.IdentityKey))
+	require.Equal(t, expected.ID, actual.ID)
+	require.Equal(t, expected.Addresses.GetAll(), actual.Addresses.GetAll())
 }
 
 // TestTowerCandidateIterator asserts the internal state of a
@@ -155,4 +161,16 @@ func TestTowerCandidateIterator(t *testing.T) {
 	towerIterator.AddCandidate(secondTower)
 	assertActiveCandidate(t, towerIterator, secondTower, true)
 	assertNextCandidate(t, towerIterator, secondTower)
+
+	// Assert that the GetTower correctly returns the tower too.
+	tower, err := towerIterator.GetTower(secondTower.ID)
+	require.NoError(t, err)
+	assertTowersEqual(t, secondTower, tower)
+
+	// Now remove the tower and assert that GetTower returns expected error.
+	err = towerIterator.RemoveCandidate(secondTower.ID, nil)
+	require.NoError(t, err)
+
+	_, err = towerIterator.GetTower(secondTower.ID)
+	require.ErrorIs(t, err, ErrTowerNotInIterator)
 }

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -2,6 +2,7 @@ package wtclient
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -868,6 +869,122 @@ func (c *TowerClient) handleChannelCloses(chanSub subscribe.Subscription) {
 		case <-c.quit:
 			return
 		}
+	}
+}
+
+// deleteSessionFromTower dials the tower that we created the session with and
+// attempts to send the tower the DeleteSession message.
+func (c *TowerClient) deleteSessionFromTower(sess *wtdb.ClientSession) error {
+	// First, we check if we have already loaded this tower in our
+	// candidate towers iterator.
+	tower, err := c.candidateTowers.GetTower(sess.TowerID)
+	if errors.Is(err, ErrTowerNotInIterator) {
+		// If not, then we attempt to load it from the DB.
+		dbTower, err := c.cfg.DB.LoadTowerByID(sess.TowerID)
+		if err != nil {
+			return err
+		}
+
+		tower, err = NewTowerFromDBTower(dbTower)
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	session, err := NewClientSessionFromDBSession(
+		sess, tower, c.cfg.SecretKeyRing,
+	)
+	if err != nil {
+		return err
+	}
+
+	localInit := wtwire.NewInitMessage(
+		lnwire.NewRawFeatureVector(wtwire.AltruistSessionsRequired),
+		c.cfg.ChainHash,
+	)
+
+	towerAddr := tower.Addresses.Peek()
+	var conn wtserver.Peer
+	// Attempt to dial the tower with its available addresses.
+	for {
+		conn, err = c.dial(
+			session.SessionKeyECDH, &lnwire.NetAddress{
+				IdentityKey: tower.IdentityKey,
+				Address:     towerAddr,
+			},
+		)
+		if err != nil {
+			// If there are more addrs available, immediately try
+			// those.
+			nextAddr, iteratorErr := tower.Addresses.Next()
+			if iteratorErr == nil {
+				towerAddr = nextAddr
+				continue
+			}
+
+			// Otherwise, if we have exhausted the address list,
+			// exit.
+			tower.Addresses.Reset()
+			return fmt.Errorf("failed to dial tower(%s) at any "+
+				"available addresses",
+				tower.IdentityKey.SerializeCompressed())
+		}
+
+		break
+	}
+	defer conn.Close()
+
+	// Send Init to tower.
+	err = c.sendMessage(conn, localInit)
+	if err != nil {
+		return err
+	}
+
+	// Receive Init from tower.
+	remoteMsg, err := c.readMessage(conn)
+	if err != nil {
+		return err
+	}
+
+	remoteInit, ok := remoteMsg.(*wtwire.Init)
+	if !ok {
+		return fmt.Errorf("watchtower %s responded with %T to Init",
+			towerAddr, remoteMsg)
+	}
+
+	// Validate Init.
+	err = localInit.CheckRemoteInit(remoteInit, wtwire.FeatureNames)
+	if err != nil {
+		return err
+	}
+
+	// Send DeleteSession to tower.
+	err = c.sendMessage(conn, &wtwire.DeleteSession{})
+	if err != nil {
+		return err
+	}
+
+	// Receive DeleteSessionReply from tower.
+	remoteMsg, err = c.readMessage(conn)
+	if err != nil {
+		return err
+	}
+
+	deleteSessionReply, ok := remoteMsg.(*wtwire.DeleteSessionReply)
+	if !ok {
+		return fmt.Errorf("watchtower %s responded with %T to "+
+			"DeleteSession", towerAddr, remoteMsg)
+	}
+
+	switch deleteSessionReply.Code {
+	case wtwire.CodeOK, wtwire.DeleteSessionCodeNotFound:
+		return nil
+	default:
+		return fmt.Errorf("received error code %v in "+
+			"DeleteSessionReply when attempting to delete "+
+			"session from tower", deleteSessionReply.Code)
 	}
 }
 

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -2,8 +2,10 @@ package wtclient
 
 import (
 	"bytes"
+	"crypto/rand"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"sync"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btclog"
 	"github.com/lightningnetwork/lnd/build"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channelnotifier"
 	"github.com/lightningnetwork/lnd/input"
@@ -43,6 +46,11 @@ const (
 	// client should abandon any pending updates or session negotiations
 	// before terminating.
 	DefaultForceQuitDelay = 10 * time.Second
+
+	// DefaultSessionCloseRange is the range over which we will generate a
+	// random number of blocks to delay closing a session after its last
+	// channel has been closed.
+	DefaultSessionCloseRange = 288
 )
 
 // genActiveSessionFilter generates a filter that selects active sessions that
@@ -141,6 +149,9 @@ type Config struct {
 	// notifications.
 	SubscribeChannelEvents func() (subscribe.Subscription, error)
 
+	// ChainNotifier can be used to subscribe to block notifications.
+	ChainNotifier chainntnfs.ChainNotifier
+
 	// IsChanClosed can be used to check if the channel with the given ID
 	// has been closed. If it has been, the block height in which its
 	// closing transaction was mined will also be returned.
@@ -201,6 +212,11 @@ type Config struct {
 	// watchtowers. If the exponential backoff produces a timeout greater
 	// than this value, the backoff will be clamped to MaxBackoff.
 	MaxBackoff time.Duration
+
+	// SessionCloseRange is the range over which we will generate a random
+	// number of blocks to delay closing a session after its last channel
+	// has been closed.
+	SessionCloseRange uint32
 }
 
 // newTowerMsg is an internal message we'll use within the TowerClient to signal
@@ -295,6 +311,10 @@ func New(config *Config) (*TowerClient, error) {
 	// Set the write timeout to the default if none was provided.
 	if cfg.WriteTimeout <= 0 {
 		cfg.WriteTimeout = DefaultWriteTimeout
+	}
+
+	if cfg.SessionCloseRange <= 0 {
+		cfg.SessionCloseRange = 1
 	}
 
 	prefix := "(legacy)"
@@ -579,6 +599,39 @@ func (c *TowerClient) Start() error {
 		c.wg.Add(1)
 		go c.handleChannelCloses(chanSub)
 
+		// Load all closable sessions.
+		sl, err := c.cfg.DB.ListClosableSessions()
+		if err != nil {
+			returnErr = err
+			return
+		}
+
+		for sID, blockHeight := range sl {
+			delay, err := newRandomDelay(c.cfg.SessionCloseRange)
+			if err != nil {
+				returnErr = err
+				return
+			}
+
+			deleteHeight := blockHeight + delay
+
+			c.closableSessionQueue.Push(&sessionCloseItem{
+				sessionID:    sID,
+				deleteHeight: deleteHeight,
+			})
+		}
+
+		blockEvents, err := c.cfg.ChainNotifier.RegisterBlockEpochNtfn(
+			nil,
+		)
+		if err != nil {
+			returnErr = err
+			return
+		}
+
+		c.wg.Add(1)
+		go c.handleClosableSessions(blockEvents)
+
 		// Now start the session negotiator, which will allow us to
 		// request new session as soon as the backupDispatcher starts
 		// up.
@@ -846,7 +899,7 @@ func (c *TowerClient) handleChannelCloses(chanSub subscribe.Subscription) {
 					continue
 				}
 
-				_, err := c.cfg.DB.MarkChannelClosed(
+				sl, err := c.cfg.DB.MarkChannelClosed(
 					chanID, closeInfo.CloseHeight,
 				)
 				if err != nil {
@@ -855,12 +908,106 @@ func (c *TowerClient) handleChannelCloses(chanSub subscribe.Subscription) {
 					continue
 				}
 
+				for _, sID := range sl {
+					delay, err := newRandomDelay(
+						c.cfg.SessionCloseRange,
+					)
+					if err != nil {
+						log.Errorf("could not "+
+							"generate delay: %v",
+							err)
+					}
+
+					deleteHeight := closeInfo.CloseHeight +
+						delay
+
+					item := &sessionCloseItem{
+						sessionID:    sID,
+						deleteHeight: deleteHeight,
+					}
+
+					c.closableSessionQueue.Push(item)
+				}
+
 				c.backupMu.Lock()
 				delete(c.summaries, chanID)
 				delete(c.chanCommitHeights, chanID)
 				c.backupMu.Unlock()
 
 			default:
+			}
+
+		case <-c.forceQuit:
+			return
+
+		case <-c.quit:
+			return
+		}
+	}
+}
+
+// handleClosableSessions listens for new block notifications. For each block,
+// it checks the closableSessionQueue to see if there is a closable session with
+// a delete-height smaller than or equal to the new block, if there is then the
+// tower is informed that it can delete the session and then we also delete it
+// from our DB.
+func (c *TowerClient) handleClosableSessions(
+	blocksChan *chainntnfs.BlockEpochEvent) {
+
+	defer c.wg.Done()
+
+	c.log.Tracef("Starting closable sessions handler")
+	defer c.log.Tracef("Stopping closable sessions handler")
+
+	for {
+		select {
+		case newBlock := <-blocksChan.Epochs:
+			if newBlock == nil {
+				return
+			}
+
+			height := uint32(newBlock.Height)
+			for {
+				select {
+				case <-c.quit:
+					return
+				default:
+				}
+
+				item := c.closableSessionQueue.Top()
+				if item == nil {
+					break
+				}
+
+				if item.deleteHeight > height {
+					break
+				}
+
+				c.closableSessionQueue.Pop()
+
+				// Fetch the session from the DB so that we can
+				// extract the Tower info.
+				sess, err := c.cfg.DB.GetClientSession(
+					item.sessionID,
+				)
+				if err != nil {
+					log.Error("error calling "+
+						"GetClientSession: %v", err)
+					continue
+				}
+
+				err = c.deleteSessionFromTower(sess)
+				if err != nil {
+					log.Error("error deleting session "+
+						"from tower: %v", err)
+					continue
+				}
+
+				err = c.cfg.DB.DeleteSession(item.sessionID)
+				if err != nil {
+					log.Errorf("could not delete "+
+						"session(%s) from DB: %v", err)
+				}
 			}
 
 		case <-c.forceQuit:
@@ -1613,4 +1760,15 @@ func (c *TowerClient) logMessage(
 	c.log.Debugf("%s %s%v %s %x@%s", action, msg.MsgType(), summary,
 		preposition, peer.RemotePub().SerializeCompressed(),
 		peer.RemoteAddr())
+}
+
+func newRandomDelay(max uint32) (uint32, error) {
+	var maxDelay big.Int
+	maxDelay.SetUint64(uint64(max))
+	_, err := rand.Int(rand.Reader, &maxDelay)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint32(maxDelay.Uint64()), nil
 }

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -424,25 +424,11 @@ func getTowerAndSessionCandidates(db DB, keyRing ECDHKeyRing,
 		}
 
 		for _, s := range sessions {
-			towerKeyDesc, err := keyRing.DeriveKey(
-				keychain.KeyLocator{
-					Family: keychain.KeyFamilyTowerSession,
-					Index:  s.KeyIndex,
-				},
+			cs, err := NewClientSessionFromDBSession(
+				s, tower, keyRing,
 			)
 			if err != nil {
 				return nil, err
-			}
-
-			sessionKeyECDH := keychain.NewPubKeyECDH(
-				towerKeyDesc, keyRing,
-			)
-
-			cs := &ClientSession{
-				ID:                s.ID,
-				ClientSessionBody: s.ClientSessionBody,
-				Tower:             tower,
-				SessionKeyECDH:    sessionKeyECDH,
 			}
 
 			if !sessionFilter(cs) {

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -257,6 +257,8 @@ type TowerClient struct {
 	sessionQueue *sessionQueue
 	prevTask     *backupTask
 
+	closableSessionQueue *sessionCloseMinHeap
+
 	backupMu          sync.Mutex
 	summaries         wtdb.ChannelSummaries
 	chanCommitHeights map[lnwire.ChannelID]uint64
@@ -308,18 +310,19 @@ func New(config *Config) (*TowerClient, error) {
 	}
 
 	c := &TowerClient{
-		cfg:               cfg,
-		log:               plog,
-		pipeline:          newTaskPipeline(plog),
-		chanCommitHeights: make(map[lnwire.ChannelID]uint64),
-		activeSessions:    make(sessionQueueSet),
-		summaries:         chanSummaries,
-		statTicker:        time.NewTicker(DefaultStatInterval),
-		stats:             new(ClientStats),
-		newTowers:         make(chan *newTowerMsg),
-		staleTowers:       make(chan *staleTowerMsg),
-		forceQuit:         make(chan struct{}),
-		quit:              make(chan struct{}),
+		cfg:                  cfg,
+		log:                  plog,
+		pipeline:             newTaskPipeline(plog),
+		chanCommitHeights:    make(map[lnwire.ChannelID]uint64),
+		activeSessions:       make(sessionQueueSet),
+		summaries:            chanSummaries,
+		closableSessionQueue: newSessionCloseMinHeap(),
+		statTicker:           time.NewTicker(DefaultStatInterval),
+		stats:                new(ClientStats),
+		newTowers:            make(chan *newTowerMsg),
+		staleTowers:          make(chan *staleTowerMsg),
+		forceQuit:            make(chan struct{}),
+		quit:                 make(chan struct{}),
 	}
 
 	// perUpdate is a callback function that will be used to inspect the

--- a/watchtower/wtclient/errors.go
+++ b/watchtower/wtclient/errors.go
@@ -1,6 +1,9 @@
 package wtclient
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	// ErrClientExiting signals that the watchtower client is shutting down.
@@ -10,6 +13,10 @@ var (
 	// cycled through all available candidates.
 	ErrTowerCandidatesExhausted = errors.New("exhausted all tower " +
 		"candidates")
+
+	// ErrTowerNotInIterator is returned when a requested tower was not
+	// found in the iterator.
+	ErrTowerNotInIterator = fmt.Errorf("tower not in iterator")
 
 	// ErrPermanentTowerFailure signals that the tower has reported that it
 	// has permanently failed or the client believes this has happened based

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -195,3 +195,30 @@ type ClientSession struct {
 	// key used to connect to the watchtower.
 	SessionKeyECDH keychain.SingleKeyECDH
 }
+
+// NewClientSessionFromDBSession converts a wtdb.ClientSession to a
+// ClientSession.
+func NewClientSessionFromDBSession(s *wtdb.ClientSession, tower *Tower,
+	keyRing ECDHKeyRing) (*ClientSession, error) {
+
+	towerKeyDesc, err := keyRing.DeriveKey(
+		keychain.KeyLocator{
+			Family: keychain.KeyFamilyTowerSession,
+			Index:  s.KeyIndex,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionKeyECDH := keychain.NewPubKeyECDH(
+		towerKeyDesc, keyRing,
+	)
+
+	return &ClientSession{
+		ID:                s.ID,
+		ClientSessionBody: s.ClientSessionBody,
+		Tower:             tower,
+		SessionKeyECDH:    sessionKeyECDH,
+	}, nil
+}

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -94,6 +94,10 @@ type DB interface {
 	MarkChannelClosed(chanID lnwire.ChannelID, blockHeight uint32) (
 		[]wtdb.SessionID, error)
 
+	// ListClosableSessions fetches and returns the IDs for all sessions
+	// marked as closable.
+	ListClosableSessions() (map[wtdb.SessionID]uint32, error)
+
 	// RegisterChannel registers a channel for use within the client
 	// database. For now, all that is stored in the channel summary is the
 	// sweep pkscript that we'd like any tower sweeps to pay into. In the

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -98,6 +98,10 @@ type DB interface {
 	// marked as closable.
 	ListClosableSessions() (map[wtdb.SessionID]uint32, error)
 
+	// DeleteSession can be called when a session should be deleted from the
+	// DB. All references to the session will also be deleted from the DB.
+	DeleteSession(id wtdb.SessionID) error
+
 	// RegisterChannel registers a channel for use within the client
 	// database. For now, all that is stored in the channel summary is the
 	// sweep pkscript that we'd like any tower sweeps to pay into. In the

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -85,6 +85,15 @@ type DB interface {
 	// their channel summaries.
 	FetchChanSummaries() (wtdb.ChannelSummaries, error)
 
+	// MarkChannelClosed will mark a registered channel as closed by setting
+	// its closed-height as the given block height. It returns a list of
+	// session IDs for sessions that are now considered closable due to the
+	// close of this channel. The details for this channel will be deleted
+	// from the DB if there are no more sessions in the DB that contain
+	// updates for this channel.
+	MarkChannelClosed(chanID lnwire.ChannelID, blockHeight uint32) (
+		[]wtdb.SessionID, error)
+
 	// RegisterChannel registers a channel for use within the client
 	// database. For now, all that is stored in the channel summary is the
 	// sweep pkscript that we'd like any tower sweeps to pay into. In the

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -63,6 +63,11 @@ type DB interface {
 	ListClientSessions(*wtdb.TowerID, ...wtdb.ClientSessionListOption) (
 		map[wtdb.SessionID]*wtdb.ClientSession, error)
 
+	// GetClientSession loads the ClientSession with the given ID from the
+	// DB.
+	GetClientSession(wtdb.SessionID,
+		...wtdb.ClientSessionListOption) (*wtdb.ClientSession, error)
+
 	// FetchSessionCommittedUpdates retrieves the current set of un-acked
 	// updates of the given session.
 	FetchSessionCommittedUpdates(id *wtdb.SessionID) (

--- a/watchtower/wtclient/sess_close_min_heap.go
+++ b/watchtower/wtclient/sess_close_min_heap.go
@@ -1,0 +1,91 @@
+package wtclient
+
+import (
+	"sync"
+
+	"github.com/lightningnetwork/lnd/queue"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb"
+)
+
+// sessionCloseMinHeap is a thread-safe min-heap implementation that stores
+// sessionCloseItem items and prioritises the item with the lowest block height.
+type sessionCloseMinHeap struct {
+	queue queue.PriorityQueue
+	mu    sync.Mutex
+}
+
+// newSessionCloseMinHeap constructs a new sessionCloseMineHeap.
+func newSessionCloseMinHeap() *sessionCloseMinHeap {
+	return &sessionCloseMinHeap{}
+}
+
+// Len returns the length of the queue.
+func (h *sessionCloseMinHeap) Len() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.queue.Len()
+}
+
+// Empty returns true if the queue is empty.
+func (h *sessionCloseMinHeap) Empty() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.queue.Empty()
+}
+
+// Push adds an item to the priority queue.
+func (h *sessionCloseMinHeap) Push(item *sessionCloseItem) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.queue.Push(item)
+}
+
+// Pop removes the top most item from the queue.
+func (h *sessionCloseMinHeap) Pop() *sessionCloseItem {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.queue.Empty() {
+		return nil
+	}
+
+	item := h.queue.Pop()
+	return item.(*sessionCloseItem)
+}
+
+// Top returns the top most item from the queue without removing it.
+func (h *sessionCloseMinHeap) Top() *sessionCloseItem {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.queue.Empty() {
+		return nil
+	}
+
+	item := h.queue.Top()
+	return item.(*sessionCloseItem)
+}
+
+// sessionCloseItem represents a session that is ready to be deleted.
+type sessionCloseItem struct {
+	// sessionID is the ID of the session in question.
+	sessionID wtdb.SessionID
+
+	// deleteHeight is the block height after which we can delete the
+	// session.
+	deleteHeight uint32
+}
+
+// Less returns true if the current item's delete height is larger than the
+// other sessionCloseItem's delete height. This results in lower block heights
+// being popped first from the heap.
+//
+// NOTE: this is part of the queue.PriorityQueueItem interface.
+func (s *sessionCloseItem) Less(other queue.PriorityQueueItem) bool {
+	return s.deleteHeight < other.(*sessionCloseItem).deleteHeight
+}
+
+var _ queue.PriorityQueueItem = (*sessionCloseItem)(nil)

--- a/watchtower/wtclient/sess_close_min_heap_test.go
+++ b/watchtower/wtclient/sess_close_min_heap_test.go
@@ -1,0 +1,50 @@
+package wtclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSessionCloseMinHeap asserts that the sessionCloseMinHeap behaves as
+// expected.
+func TestSessionCloseMinHeap(t *testing.T) {
+	heap := newSessionCloseMinHeap()
+	require.Nil(t, heap.Pop())
+	require.Nil(t, heap.Top())
+	require.True(t, heap.Empty())
+	require.Zero(t, heap.Len())
+
+	// Add an item with height 10.
+	item1 := &sessionCloseItem{
+		sessionID:    [33]byte{1, 2, 3},
+		deleteHeight: 10,
+	}
+
+	heap.Push(item1)
+	require.Equal(t, item1, heap.Top())
+	require.False(t, heap.Empty())
+	require.EqualValues(t, 1, heap.Len())
+
+	// Add a bunch more items with heights 1, 2, 6, 11, 6, 30, 9.
+	heap.Push(&sessionCloseItem{deleteHeight: 1})
+	heap.Push(&sessionCloseItem{deleteHeight: 2})
+	heap.Push(&sessionCloseItem{deleteHeight: 6})
+	heap.Push(&sessionCloseItem{deleteHeight: 11})
+	heap.Push(&sessionCloseItem{deleteHeight: 6})
+	heap.Push(&sessionCloseItem{deleteHeight: 30})
+	heap.Push(&sessionCloseItem{deleteHeight: 9})
+
+	// Now pop from the queue and assert that the items are returned in
+	// ascending order.
+	require.EqualValues(t, 1, heap.Pop().deleteHeight)
+	require.EqualValues(t, 2, heap.Pop().deleteHeight)
+	require.EqualValues(t, 6, heap.Pop().deleteHeight)
+	require.EqualValues(t, 6, heap.Pop().deleteHeight)
+	require.EqualValues(t, 9, heap.Pop().deleteHeight)
+	require.EqualValues(t, 10, heap.Pop().deleteHeight)
+	require.EqualValues(t, 11, heap.Pop().deleteHeight)
+	require.EqualValues(t, 30, heap.Pop().deleteHeight)
+	require.Nil(t, heap.Pop())
+	require.Zero(t, heap.Len())
+}

--- a/watchtower/wtdb/client_db.go
+++ b/watchtower/wtdb/client_db.go
@@ -888,20 +888,14 @@ func (c *ClientDB) ListClientSessions(id *TowerID,
 			return ErrUninitializedDB
 		}
 
-		towers := tx.ReadBucket(cTowerBkt)
-		if towers == nil {
-			return ErrUninitializedDB
-		}
-
 		chanIDIndexBkt := tx.ReadBucket(cChanIDIndexBkt)
 		if chanIDIndexBkt == nil {
 			return ErrUninitializedDB
 		}
 
-		var err error
-
 		// If no tower ID is specified, then fetch all the sessions
 		// known to the db.
+		var err error
 		if id == nil {
 			clientSessions, err = c.listClientAllSessions(
 				sessions, chanIDIndexBkt, opts...,

--- a/watchtower/wtdb/client_db.go
+++ b/watchtower/wtdb/client_db.go
@@ -875,6 +875,39 @@ func getSessionKeyIndex(keyIndexes kvdb.RwBucket, towerID TowerID,
 	return byteOrder.Uint32(keyIndexBytes), nil
 }
 
+// GetClientSession loads the ClientSession with the given ID from the DB.
+func (c *ClientDB) GetClientSession(id SessionID,
+	opts ...ClientSessionListOption) (*ClientSession, error) {
+
+	var sess *ClientSession
+	err := kvdb.View(c.db, func(tx kvdb.RTx) error {
+		sessionsBkt := tx.ReadBucket(cSessionBkt)
+		if sessionsBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		chanIDIndexBkt := tx.ReadBucket(cChanIDIndexBkt)
+		if chanIDIndexBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		session, err := c.getClientSession(
+			sessionsBkt, chanIDIndexBkt, id[:], opts...,
+		)
+		if err != nil {
+			return err
+		}
+
+		sess = session
+		return nil
+	}, func() {})
+	if err != nil {
+		return nil, err
+	}
+
+	return sess, nil
+}
+
 // ListClientSessions returns the set of all client sessions known to the db. An
 // optional tower ID can be used to filter out any client sessions in the
 // response that do not correspond to this tower.

--- a/watchtower/wtdb/client_db.go
+++ b/watchtower/wtdb/client_db.go
@@ -1285,6 +1285,39 @@ func (c *ClientDB) MarkBackupIneligible(chanID lnwire.ChannelID,
 	return nil
 }
 
+// ListClosableSessions fetches and returns the IDs for all sessions marked as
+// closable.
+func (c *ClientDB) ListClosableSessions() (map[SessionID]uint32, error) {
+	sessions := make(map[SessionID]uint32)
+	err := kvdb.View(c.db, func(tx kvdb.RTx) error {
+		csBkt := tx.ReadBucket(cClosableSessionsBkt)
+		if csBkt == nil {
+			return nil
+		}
+
+		sessIDIndexBkt := tx.ReadBucket(cSessionIDIndexBkt)
+		if sessIDIndexBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		return csBkt.ForEach(func(dbIDBytes, heightBytes []byte) error {
+			dbID := byteOrder.Uint64(dbIDBytes)
+			sessID, err := getRealSessionID(sessIDIndexBkt, dbID)
+			if err != nil {
+				return err
+			}
+
+			sessions[*sessID] = byteOrder.Uint32(heightBytes)
+			return nil
+		})
+	}, func() {})
+	if err != nil {
+		return nil, err
+	}
+
+	return sessions, nil
+}
+
 // MarkChannelClosed will mark a registered channel as closed by setting its
 // closed-height as the given block height. It returns a list of session IDs for
 // sessions that are now considered closable due to the close of this channel.

--- a/watchtower/wtdb/client_db.go
+++ b/watchtower/wtdb/client_db.go
@@ -156,9 +156,18 @@ var (
 	// watchtower is attempted to be removed.
 	ErrLastTowerAddr = errors.New("cannot remove last tower address")
 
+	// ErrSessionNotClosable is returned when a session is not found in the
+	// closable list.
+	ErrSessionNotClosable = errors.New("session is not closable")
+
 	// errSessionHasOpenChannels is an error used to indicate that a
 	// session has updates for channels that are still open.
 	errSessionHasOpenChannels = errors.New("session has open channels")
+
+	// errChannelHasMoreSessions is an error used to indicate that a channel
+	// has updates in other non-closed sessions.
+	errChannelHasMoreSessions = errors.New("channel has updates in " +
+		"other sessions")
 )
 
 // NewBoltBackendCreator returns a function that creates a new bbolt backend for
@@ -1316,6 +1325,154 @@ func (c *ClientDB) ListClosableSessions() (map[SessionID]uint32, error) {
 	}
 
 	return sessions, nil
+}
+
+// DeleteSession can be called when a session should be deleted from the DB.
+// All references to the session will also be deleted from the DB.
+func (c *ClientDB) DeleteSession(id SessionID) error {
+	return kvdb.Update(c.db, func(tx kvdb.RwTx) error {
+		// Get some session info: dbID & channel List.
+		sessionsBkt := tx.ReadWriteBucket(cSessionBkt)
+		if sessionsBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		closableBkt := tx.ReadWriteBucket(cClosableSessionsBkt)
+		if closableBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		chanDetailsBkt := tx.ReadWriteBucket(cChanDetailsBkt)
+		if chanDetailsBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		sessIDIndexBkt := tx.ReadWriteBucket(cSessionIDIndexBkt)
+		if sessIDIndexBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		chanIDIndexBkt := tx.ReadWriteBucket(cChanIDIndexBkt)
+		if chanIDIndexBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		towerToSessBkt := tx.ReadWriteBucket(cTowerToSessionIndexBkt)
+		if towerToSessBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		sessionBkt := sessionsBkt.NestedReadBucket(id[:])
+		if sessionBkt == nil {
+			return nil
+		}
+
+		_, dbIDBytes, err := getDBSessionID(sessionsBkt, id)
+		if err != nil {
+			return err
+		}
+
+		// First we check if the session has actually been marked as
+		// closable.
+		if len(closableBkt.Get(dbIDBytes)) == 0 {
+			return ErrSessionNotClosable
+		}
+
+		sess, err := getClientSessionBody(sessionsBkt, id[:])
+		if err != nil {
+			return err
+		}
+
+		// Delete from the tower-to-sessionID index.
+		towerIndexBkt := towerToSessBkt.NestedReadWriteBucket(
+			sess.TowerID.Bytes(),
+		)
+		if towerIndexBkt != nil {
+			err = towerIndexBkt.Delete(id[:])
+			if err != nil {
+				return err
+			}
+		}
+
+		// Delete entry from session ID index.
+		err = sessIDIndexBkt.Delete(dbIDBytes)
+		if err != nil {
+			return err
+		}
+
+		// Delete the entry from closable sessions.
+		err = closableBkt.Delete(dbIDBytes)
+		if err != nil {
+			return err
+		}
+
+		ackRanges := sessionBkt.NestedReadBucket(cSessionAckRangeIndex)
+		if ackRanges == nil {
+			// If the session has no acked updates for any
+			// channels, we can just delete the whole session.
+			return sessionsBkt.DeleteNestedBucket(id[:])
+		}
+
+		// Otherwise, for each of the channels, delete the session ID
+		// entry.
+		err = ackRanges.ForEach(func(chanDBID, _ []byte) error {
+			chanID, err := getRealChannelID(
+				chanIDIndexBkt, byteOrder.Uint64(chanDBID),
+			)
+			if err != nil {
+				return err
+			}
+
+			chanDetails := chanDetailsBkt.NestedReadWriteBucket(
+				chanID[:],
+			)
+			if chanDetails == nil {
+				return ErrChannelNotRegistered
+			}
+
+			chanSessions := chanDetails.NestedReadWriteBucket(
+				cChanSessions,
+			)
+			if chanSessions == nil {
+				return fmt.Errorf("session not found in " +
+					"channel list")
+			}
+
+			err = chanSessions.Delete(dbIDBytes)
+			if err != nil {
+				return err
+			}
+
+			// If this was the last session for this channel, we can
+			// now delete the channel details for this channel
+			// completely.
+			err = chanSessions.ForEach(func(_, _ []byte) error {
+				return errChannelHasMoreSessions
+			})
+			if errors.Is(err, errChannelHasMoreSessions) {
+				return nil
+			} else if err != nil {
+				return err
+			}
+
+			// Delete from channel-id-index bkt.
+			dbID := chanDetails.Get(cChanDBID)
+			err = chanIDIndexBkt.Delete(dbID)
+			if err != nil {
+				return err
+			}
+
+			// Delete the channel details.
+			return chanDetailsBkt.DeleteNestedBucket(chanID[:])
+		})
+		if err != nil {
+			return err
+		}
+
+		// Delete the actual session.
+		return sessionsBkt.DeleteNestedBucket(id[:])
+
+	}, func() {})
 }
 
 // MarkChannelClosed will mark a registered channel as closed by setting its

--- a/watchtower/wtdb/client_db_test.go
+++ b/watchtower/wtdb/client_db_test.go
@@ -206,6 +206,17 @@ func (h *clientDBHarness) markChannelClosed(id lnwire.ChannelID,
 	return closableSessions
 }
 
+func (h *clientDBHarness) listClosableSessions(
+	expErr error) map[wtdb.SessionID]uint32 {
+
+	h.t.Helper()
+
+	closableSessions, err := h.db.ListClosableSessions()
+	require.ErrorIs(h.t, err, expErr)
+
+	return closableSessions
+}
+
 // newTower is a helper function that creates a new tower with a randomly
 // generated public key and inserts it into the client DB.
 func (h *clientDBHarness) newTower() *wtdb.Tower {
@@ -710,11 +721,16 @@ func testMarkChannelClosed(h *clientDBHarness) {
 	// since it has an update for channel 6 which is still open.
 	sl = h.markChannelClosed(chanID5, 1, nil)
 	require.Empty(h.t, sl)
+	require.Empty(h.t, h.listClosableSessions(nil))
 
 	// Finally, if we close channel 6, session 1 _should_ be in the closable
 	// list.
-	sl = h.markChannelClosed(chanID6, 1, nil)
+	sl = h.markChannelClosed(chanID6, 100, nil)
 	require.ElementsMatch(h.t, sl, []wtdb.SessionID{session1.ID})
+	slMap := h.listClosableSessions(nil)
+	require.InDeltaMapValues(h.t, slMap, map[wtdb.SessionID]uint32{
+		session1.ID: 100,
+	}, 0)
 }
 
 // testAckUpdate asserts the behavior of AckUpdate.

--- a/watchtower/wtdb/client_db_test.go
+++ b/watchtower/wtdb/client_db_test.go
@@ -217,6 +217,13 @@ func (h *clientDBHarness) listClosableSessions(
 	return closableSessions
 }
 
+func (h *clientDBHarness) deleteSession(id wtdb.SessionID, expErr error) {
+	h.t.Helper()
+
+	err := h.db.DeleteSession(id)
+	require.ErrorIs(h.t, err, expErr)
+}
+
 // newTower is a helper function that creates a new tower with a randomly
 // generated public key and inserts it into the client DB.
 func (h *clientDBHarness) newTower() *wtdb.Tower {
@@ -723,6 +730,10 @@ func testMarkChannelClosed(h *clientDBHarness) {
 	require.Empty(h.t, sl)
 	require.Empty(h.t, h.listClosableSessions(nil))
 
+	// Also check that attempting to delete the session will fail since it
+	// is not yet considered closable.
+	h.deleteSession(session1.ID, wtdb.ErrSessionNotClosable)
+
 	// Finally, if we close channel 6, session 1 _should_ be in the closable
 	// list.
 	sl = h.markChannelClosed(chanID6, 100, nil)
@@ -731,6 +742,10 @@ func testMarkChannelClosed(h *clientDBHarness) {
 	require.InDeltaMapValues(h.t, slMap, map[wtdb.SessionID]uint32{
 		session1.ID: 100,
 	}, 0)
+
+	// Assert that we now can delete the session.
+	h.deleteSession(session1.ID, nil)
+	require.Empty(h.t, h.listClosableSessions(nil))
 }
 
 // testAckUpdate asserts the behavior of AckUpdate.

--- a/watchtower/wtdb/client_db_test.go
+++ b/watchtower/wtdb/client_db_test.go
@@ -3,6 +3,7 @@ package wtdb_test
 import (
 	crand "crypto/rand"
 	"io"
+	"math/rand"
 	"net"
 	"testing"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtpolicy"
 	"github.com/stretchr/testify/require"
 )
+
+const blobType = blob.TypeAltruistCommit
 
 // pseudoAddr is a fake network address to be used for testing purposes.
 var pseudoAddr = &net.TCPAddr{IP: []byte{0x01, 0x00, 0x00, 0x00}, Port: 9911}
@@ -190,6 +193,17 @@ func (h *clientDBHarness) ackUpdate(id *wtdb.SessionID, seqNum uint16,
 
 	err := h.db.AckUpdate(id, seqNum, lastApplied)
 	require.ErrorIs(h.t, err, expErr)
+}
+
+func (h *clientDBHarness) markChannelClosed(id lnwire.ChannelID,
+	blockHeight uint32, expErr error) []wtdb.SessionID {
+
+	h.t.Helper()
+
+	closableSessions, err := h.db.MarkChannelClosed(id, blockHeight)
+	require.ErrorIs(h.t, err, expErr)
+
+	return closableSessions
 }
 
 // newTower is a helper function that creates a new tower with a randomly
@@ -604,6 +618,105 @@ func testCommitUpdate(h *clientDBHarness) {
 	}, nil)
 }
 
+// testMarkChannelClosed asserts the behaviour of MarkChannelClosed.
+func testMarkChannelClosed(h *clientDBHarness) {
+	tower := h.newTower()
+
+	// Create channel 1.
+	chanID1 := randChannelID(h.t)
+
+	// Since we have not yet registered the channel, we expect an error
+	// when attempting to mark it as closed.
+	h.markChannelClosed(chanID1, 1, wtdb.ErrChannelNotRegistered)
+
+	// Now register the channel.
+	h.registerChan(chanID1, nil, nil)
+
+	// Since there are still no sessions that would have updates for the
+	// channel, marking it as closed now should succeed.
+	h.markChannelClosed(chanID1, 1, nil)
+
+	// Register channel 2.
+	chanID2 := randChannelID(h.t)
+	h.registerChan(chanID2, nil, nil)
+
+	// Create session1 with MaxUpdates set to 5.
+	session1 := h.randSession(h.t, tower.ID, 5)
+	h.insertSession(session1, nil)
+
+	// Add an update for channel 2 in session 1 and ack it too.
+	update := randCommittedUpdateForChannel(h.t, chanID2, 1)
+	lastApplied := h.commitUpdate(&session1.ID, update, nil)
+	require.Zero(h.t, lastApplied)
+	h.ackUpdate(&session1.ID, 1, 1, nil)
+
+	// Marking channel 2 now should not result in any closable sessions
+	// since session 1 is not yet exhausted.
+	sl := h.markChannelClosed(chanID2, 1, nil)
+	require.Empty(h.t, sl)
+
+	// Create channel 3 and 4.
+	chanID3 := randChannelID(h.t)
+	h.registerChan(chanID3, nil, nil)
+
+	chanID4 := randChannelID(h.t)
+	h.registerChan(chanID4, nil, nil)
+
+	// Add an update for channel 4 and ack it.
+	update = randCommittedUpdateForChannel(h.t, chanID4, 2)
+	lastApplied = h.commitUpdate(&session1.ID, update, nil)
+	require.EqualValues(h.t, 1, lastApplied)
+	h.ackUpdate(&session1.ID, 2, 2, nil)
+
+	// Add an update for channel 3 in session 1. But dont ack it yet.
+	update = randCommittedUpdateForChannel(h.t, chanID2, 3)
+	lastApplied = h.commitUpdate(&session1.ID, update, nil)
+	require.EqualValues(h.t, 2, lastApplied)
+
+	// Mark channel 4 as closed & assert that session 1 is not seen as
+	// closable since it still has committed updates.
+	sl = h.markChannelClosed(chanID4, 1, nil)
+	require.Empty(h.t, sl)
+
+	// Now ack the update we added above.
+	h.ackUpdate(&session1.ID, 3, 3, nil)
+
+	// Mark channel 3 as closed & assert that session 1 is still not seen as
+	// closable since it is not yet exhausted.
+	sl = h.markChannelClosed(chanID3, 1, nil)
+	require.Empty(h.t, sl)
+
+	// Create channel 5 and 6.
+	chanID5 := randChannelID(h.t)
+	h.registerChan(chanID5, nil, nil)
+
+	chanID6 := randChannelID(h.t)
+	h.registerChan(chanID6, nil, nil)
+
+	// Add an update for channel 5 and ack it.
+	update = randCommittedUpdateForChannel(h.t, chanID5, 4)
+	lastApplied = h.commitUpdate(&session1.ID, update, nil)
+	require.EqualValues(h.t, 3, lastApplied)
+	h.ackUpdate(&session1.ID, 4, 4, nil)
+
+	// Add an update for channel 6 and ack it.
+	update = randCommittedUpdateForChannel(h.t, chanID6, 5)
+	lastApplied = h.commitUpdate(&session1.ID, update, nil)
+	require.EqualValues(h.t, 4, lastApplied)
+	h.ackUpdate(&session1.ID, 5, 5, nil)
+
+	// The session is no exhausted.
+	// If we now close channel 5, session 1 should still not be closable
+	// since it has an update for channel 6 which is still open.
+	sl = h.markChannelClosed(chanID5, 1, nil)
+	require.Empty(h.t, sl)
+
+	// Finally, if we close channel 6, session 1 _should_ be in the closable
+	// list.
+	sl = h.markChannelClosed(chanID6, 1, nil)
+	require.ElementsMatch(h.t, sl, []wtdb.SessionID{session1.ID})
+}
+
 // testAckUpdate asserts the behavior of AckUpdate.
 func testAckUpdate(h *clientDBHarness) {
 	const blobType = blob.TypeAltruistCommit
@@ -820,6 +933,10 @@ func TestClientDB(t *testing.T) {
 			name: "ack update",
 			run:  testAckUpdate,
 		},
+		{
+			name: "mark channel closed",
+			run:  testMarkChannelClosed,
+		},
 	}
 
 	for _, database := range dbs {
@@ -840,12 +957,30 @@ func TestClientDB(t *testing.T) {
 
 // randCommittedUpdate generates a random committed update.
 func randCommittedUpdate(t *testing.T, seqNum uint16) *wtdb.CommittedUpdate {
+	t.Helper()
+
+	chanID := randChannelID(t)
+	return randCommittedUpdateForChannel(t, chanID, seqNum)
+}
+
+func randChannelID(t *testing.T) lnwire.ChannelID {
+	t.Helper()
+
 	var chanID lnwire.ChannelID
 	_, err := io.ReadFull(crand.Reader, chanID[:])
 	require.NoError(t, err)
+	return chanID
+}
+
+// randCommittedUpdateForChannel generates a random committed update for the
+// given channel ID.
+func randCommittedUpdateForChannel(t *testing.T, chanID lnwire.ChannelID,
+	seqNum uint16) *wtdb.CommittedUpdate {
+
+	t.Helper()
 
 	var hint blob.BreachHint
-	_, err = io.ReadFull(crand.Reader, hint[:])
+	_, err := io.ReadFull(crand.Reader, hint[:])
 	require.NoError(t, err)
 
 	encBlob := make([]byte, blob.Size(blob.FlagCommitOutputs.Type()))
@@ -862,5 +997,28 @@ func randCommittedUpdate(t *testing.T, seqNum uint16) *wtdb.CommittedUpdate {
 			Hint:          hint,
 			EncryptedBlob: encBlob,
 		},
+	}
+}
+
+func (h *clientDBHarness) randSession(t *testing.T,
+	towerID wtdb.TowerID, maxUpdates uint16) *wtdb.ClientSession {
+
+	t.Helper()
+
+	var id wtdb.SessionID
+	rand.Read(id[:])
+	return &wtdb.ClientSession{
+		ClientSessionBody: wtdb.ClientSessionBody{
+			TowerID: towerID,
+			Policy: wtpolicy.Policy{
+				TxPolicy: wtpolicy.TxPolicy{
+					BlobType: blobType,
+				},
+				MaxUpdates: maxUpdates,
+			},
+			RewardPkScript: []byte{0x01, 0x02, 0x03},
+			KeyIndex:       h.nextKeyIndex(towerID, blobType),
+		},
+		ID: id,
 	}
 }

--- a/watchtower/wtdb/log.go
+++ b/watchtower/wtdb/log.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration3"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration4"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration5"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration6"
 )
 
 // log is a logger that is initialized with no output filters.  This
@@ -36,6 +37,7 @@ func UseLogger(logger btclog.Logger) {
 	migration3.UseLogger(logger)
 	migration4.UseLogger(logger)
 	migration5.UseLogger(logger)
+	migration6.UseLogger(logger)
 }
 
 // logClosure is used to provide a closure over expensive logging operations so

--- a/watchtower/wtdb/migration6/client_db.go
+++ b/watchtower/wtdb/migration6/client_db.go
@@ -1,0 +1,168 @@
+package migration6
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+var (
+	// cSessionBkt is a top-level bucket storing:
+	//   session-id => cSessionBody -> encoded ClientSessionBody
+	// 		=> cSessionDBID -> db-assigned-id
+	//              => cSessionCommits => seqnum -> encoded CommittedUpdate
+	//              => cSessionAckRangeIndex => chan-id => acked-index-range
+	cSessionBkt = []byte("client-session-bucket")
+
+	// cChanDetailsBkt is a top-level bucket storing:
+	//   channel-id => cChannelSummary -> encoded ClientChanSummary.
+	//  		=> cChanDBID -> db-assigned-id
+	// 		=> cChanSessions => session-id -> []byte{1}
+	cChanDetailsBkt = []byte("client-channel-detail-bucket")
+
+	// cChannelSummary is a sub-bucket of cChanDetailsBkt which stores the
+	// encoded body of ClientChanSummary.
+	cChannelSummary = []byte("client-channel-summary")
+
+	// cChanSessions is a sub-bucket of cChanDetailsBkt which stores:
+	//    session-id -> 1
+	cChanSessions = []byte("client-channel-sessions")
+
+	// cSessionAckRangeIndex is a sub-bucket of cSessionBkt storing:
+	//    chan-id => start -> end
+	cSessionAckRangeIndex = []byte("client-session-ack-range-index")
+
+	// cSessionDBID is a key used in the cSessionBkt to store the
+	// db-assigned-d of a session.
+	cSessionDBID = []byte("client-session-db-id")
+
+	// cChanIDIndexBkt is a top-level bucket storing:
+	//    db-assigned-id -> channel-ID
+	cChanIDIndexBkt = []byte("client-channel-id-index")
+
+	// ErrUninitializedDB signals that top-level buckets for the database
+	// have not been initialized.
+	ErrUninitializedDB = errors.New("db not initialized")
+
+	// ErrCorruptClientSession signals that the client session's on-disk
+	// structure deviates from what is expected.
+	ErrCorruptClientSession = errors.New("client session corrupted")
+
+	// byteOrder is the default endianness used when serializing integers.
+	byteOrder = binary.BigEndian
+)
+
+// MigrateChannelToSessionIndex migrates the tower client DB to add an index
+// from channel-to-session. This will make it easier in future to check which
+// sessions have updates for which channels.
+func MigrateChannelToSessionIndex(tx kvdb.RwTx) error {
+	log.Infof("Migrating the tower client DB to build a new " +
+		"channel-to-session index")
+
+	sessionsBkt := tx.ReadBucket(cSessionBkt)
+	if sessionsBkt == nil {
+		return ErrUninitializedDB
+	}
+
+	chanDetailsBkt := tx.ReadWriteBucket(cChanDetailsBkt)
+	if chanDetailsBkt == nil {
+		return ErrUninitializedDB
+	}
+
+	chanIDsBkt := tx.ReadBucket(cChanIDIndexBkt)
+	if chanIDsBkt == nil {
+		return ErrUninitializedDB
+	}
+
+	// First gather all the new channel-to-session pairs that we want to
+	// add.
+	index, err := collectIndex(sessionsBkt)
+	if err != nil {
+		return err
+	}
+
+	// Then persist those pairs to the db.
+	return persistIndex(chanDetailsBkt, chanIDsBkt, index)
+}
+
+// collectIndex iterates through all the sessions and uses the keys in the
+// cSessionAckRangeIndex bucket to collect all the channels that the session
+// has updates for. The function returns a map from channel ID to session ID
+// (using the db-assigned IDs for both).
+func collectIndex(sessionsBkt kvdb.RBucket) (map[uint64]map[uint64]bool,
+	error) {
+
+	index := make(map[uint64]map[uint64]bool)
+	err := sessionsBkt.ForEach(func(sessID, _ []byte) error {
+		sessionBkt := sessionsBkt.NestedReadBucket(sessID)
+		if sessionBkt == nil {
+			return ErrCorruptClientSession
+		}
+
+		ackedRanges := sessionBkt.NestedReadBucket(
+			cSessionAckRangeIndex,
+		)
+		if ackedRanges == nil {
+			return nil
+		}
+
+		sessDBIDBytes := sessionBkt.Get(cSessionDBID)
+		if sessDBIDBytes == nil {
+			return ErrCorruptClientSession
+		}
+
+		sessDBID := byteOrder.Uint64(sessDBIDBytes)
+
+		return ackedRanges.ForEach(func(dbChanIDBytes, _ []byte) error {
+			dbChanID := byteOrder.Uint64(dbChanIDBytes)
+
+			if _, ok := index[dbChanID]; !ok {
+				index[dbChanID] = make(map[uint64]bool)
+			}
+
+			index[dbChanID][sessDBID] = true
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return index, nil
+}
+
+// persistIndex adds the channel-to-session mapping in each channel's details
+// bucket.
+func persistIndex(chanDetailsBkt kvdb.RwBucket, chanIDsBkt kvdb.RBucket,
+	index map[uint64]map[uint64]bool) error {
+
+	for dbChanID, sessIDs := range index {
+		var dbChanIDBytes [8]byte
+		byteOrder.PutUint64(dbChanIDBytes[:], dbChanID)
+		realChanID := chanIDsBkt.Get(dbChanIDBytes[:])
+
+		chanBkt := chanDetailsBkt.NestedReadWriteBucket(realChanID)
+		if chanBkt == nil {
+			return fmt.Errorf("channel not found")
+		}
+
+		sessIDsBkt, err := chanBkt.CreateBucket(cChanSessions)
+		if err != nil {
+			return err
+		}
+
+		for id := range sessIDs {
+			var sessID [8]byte
+			byteOrder.PutUint64(sessID[:], id)
+
+			err = sessIDsBkt.Put(sessID[:], []byte{1})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/watchtower/wtdb/migration6/client_db_test.go
+++ b/watchtower/wtdb/migration6/client_db_test.go
@@ -1,0 +1,185 @@
+package migration6
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/channeldb/migtest"
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+var (
+
+	// preDetails is the expected data of the channel details bucket before
+	// the migration.
+	preDetails = map[string]interface{}{
+		channelIDString(100): map[string]interface{}{
+			string(cChannelSummary): string([]byte{1, 2, 3}),
+		},
+		channelIDString(222): map[string]interface{}{
+			string(cChannelSummary): string([]byte{4, 5, 6}),
+		},
+	}
+
+	// preFailCorruptDB should fail the migration due to no channel summary
+	// being found for a given channel ID.
+	preFailCorruptDB = map[string]interface{}{
+		channelIDString(30): map[string]interface{}{},
+	}
+
+	// channelIDIndex is the data in the channelID index that is used to
+	// find the mapping between the db-assigned channel ID and the real
+	// channel ID.
+	channelIDIndex = map[string]interface{}{
+		uint64ToStr(10): channelIDString(100),
+		uint64ToStr(20): channelIDString(222),
+	}
+
+	// sessions is the expected data in the sessions bucket before and
+	// after the migration.
+	sessions = map[string]interface{}{
+		sessionIDString("1"): map[string]interface{}{
+			string(cSessionAckRangeIndex): map[string]interface{}{
+				uint64ToStr(10): map[string]interface{}{
+					uint64ToStr(30): uint64ToStr(32),
+					uint64ToStr(34): uint64ToStr(34),
+				},
+				uint64ToStr(20): map[string]interface{}{
+					uint64ToStr(30): uint64ToStr(30),
+				},
+			},
+			string(cSessionDBID): uint64ToStr(66),
+		},
+		sessionIDString("2"): map[string]interface{}{
+			string(cSessionAckRangeIndex): map[string]interface{}{
+				uint64ToStr(10): map[string]interface{}{
+					uint64ToStr(33): uint64ToStr(33),
+				},
+			},
+			string(cSessionDBID): uint64ToStr(77),
+		},
+	}
+
+	// postDetails is the expected data in the channel details bucket after
+	// the migration.
+	postDetails = map[string]interface{}{
+		channelIDString(100): map[string]interface{}{
+			string(cChannelSummary): string([]byte{1, 2, 3}),
+			string(cChanSessions): map[string]interface{}{
+				uint64ToStr(66): string([]byte{1}),
+				uint64ToStr(77): string([]byte{1}),
+			},
+		},
+		channelIDString(222): map[string]interface{}{
+			string(cChannelSummary): string([]byte{4, 5, 6}),
+			string(cChanSessions): map[string]interface{}{
+				uint64ToStr(66): string([]byte{1}),
+			},
+		},
+	}
+)
+
+// TestMigrateChannelToSessionIndex tests that the MigrateChannelToSessionIndex
+// function correctly builds the new channel-to-sessionID index to the tower
+// client DB.
+func TestMigrateChannelToSessionIndex(t *testing.T) {
+	tests := []struct {
+		name         string
+		shouldFail   bool
+		preDetails   map[string]interface{}
+		preSessions  map[string]interface{}
+		preChanIndex map[string]interface{}
+		postDetails  map[string]interface{}
+	}{
+		{
+			name:         "migration ok",
+			shouldFail:   false,
+			preDetails:   preDetails,
+			preSessions:  sessions,
+			preChanIndex: channelIDIndex,
+			postDetails:  postDetails,
+		},
+		{
+			name:        "fail due to corrupt db",
+			shouldFail:  true,
+			preDetails:  preFailCorruptDB,
+			preSessions: sessions,
+		},
+		{
+			name:       "no sessions",
+			shouldFail: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			// Before the migration we have a channel details
+			// bucket, a sessions bucket, a session ID index bucket
+			// and a channel ID index bucket.
+			before := func(tx kvdb.RwTx) error {
+				err := migtest.RestoreDB(
+					tx, cChanDetailsBkt, test.preDetails,
+				)
+				if err != nil {
+					return err
+				}
+
+				err = migtest.RestoreDB(
+					tx, cSessionBkt, test.preSessions,
+				)
+				if err != nil {
+					return err
+				}
+
+				return migtest.RestoreDB(
+					tx, cChanIDIndexBkt, test.preChanIndex,
+				)
+			}
+
+			after := func(tx kvdb.RwTx) error {
+				// If the migration fails, the details bucket
+				// should be untouched.
+				if test.shouldFail {
+					if err := migtest.VerifyDB(
+						tx, cChanDetailsBkt,
+						test.preDetails,
+					); err != nil {
+						return err
+					}
+
+					return nil
+				}
+
+				// Else, we expect an updated details bucket
+				// and a new index bucket.
+				return migtest.VerifyDB(
+					tx, cChanDetailsBkt, test.postDetails,
+				)
+			}
+
+			migtest.ApplyMigration(
+				t, before, after, MigrateChannelToSessionIndex,
+				test.shouldFail,
+			)
+		})
+	}
+}
+
+func sessionIDString(id string) string {
+	var sessID SessionID
+	copy(sessID[:], id)
+	return sessID.String()
+}
+
+func channelIDString(id uint64) string {
+	var chanID ChannelID
+	byteOrder.PutUint64(chanID[:], id)
+	return string(chanID[:])
+}
+
+func uint64ToStr(id uint64) string {
+	var b [8]byte
+	byteOrder.PutUint64(b[:], id)
+	return string(b[:])
+}

--- a/watchtower/wtdb/migration6/codec.go
+++ b/watchtower/wtdb/migration6/codec.go
@@ -1,0 +1,29 @@
+package migration6
+
+import "encoding/hex"
+
+// SessionIDSize is 33-bytes; it is a serialized, compressed public key.
+const SessionIDSize = 33
+
+// SessionID is created from the remote public key of a client, and serves as a
+// unique identifier and authentication for sending state updates.
+type SessionID [SessionIDSize]byte
+
+// String returns a hex encoding of the session id.
+func (s SessionID) String() string {
+	return hex.EncodeToString(s[:])
+}
+
+// ChannelID is a series of 32-bytes that uniquely identifies all channels
+// within the network. The ChannelID is computed using the outpoint of the
+// funding transaction (the txid, and output index). Given a funding output the
+// ChannelID can be calculated by XOR'ing the big-endian serialization of the
+// txid and the big-endian serialization of the output index, truncated to
+// 2 bytes.
+type ChannelID [32]byte
+
+// String returns the string representation of the ChannelID. This is just the
+// hex string encoding of the ChannelID itself.
+func (c ChannelID) String() string {
+	return hex.EncodeToString(c[:])
+}

--- a/watchtower/wtdb/migration6/log.go
+++ b/watchtower/wtdb/migration6/log.go
@@ -1,0 +1,14 @@
+package migration6
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized as disabled.  This means the package will
+// not perform any logging by default until a logger is set.
+var log = btclog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/watchtower/wtdb/version.go
+++ b/watchtower/wtdb/version.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration3"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration4"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration5"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration6"
 )
 
 // migration is a function which takes a prior outdated version of the database
@@ -44,6 +45,9 @@ var clientDBVersions = []version{
 	},
 	{
 		migration: migration5.MigrateAckedUpdates,
+	},
+	{
+		migration: migration6.MigrateChannelToSessionIndex,
 	},
 }
 

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -502,6 +502,20 @@ func (m *ClientDB) AckUpdate(id *wtdb.SessionID, seqNum,
 	return wtdb.ErrCommittedUpdateNotFound
 }
 
+// ListClosableSessions fetches and returns the IDs for all sessions marked as
+// closable.
+func (m *ClientDB) ListClosableSessions() (map[wtdb.SessionID]uint32, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cs := make(map[wtdb.SessionID]uint32, len(m.closableSessions))
+	for id, height := range m.closableSessions {
+		cs[id] = height
+	}
+
+	return cs, nil
+}
+
 // FetchChanSummaries loads a mapping from all registered channels to their
 // channel summaries.
 func (m *ClientDB) FetchChanSummaries() (wtdb.ChannelSummaries, error) {

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -18,18 +18,25 @@ type keyIndexKey struct {
 	blobType blob.Type
 }
 
+type channel struct {
+	summary      *wtdb.ClientChanSummary
+	closedHeight uint32
+	sessions     map[wtdb.SessionID]bool
+}
+
 // ClientDB is a mock, in-memory database or testing the watchtower client
 // behavior.
 type ClientDB struct {
 	nextTowerID uint64 // to be used atomically
 
 	mu               sync.Mutex
-	summaries        map[lnwire.ChannelID]wtdb.ClientChanSummary
+	channels         map[lnwire.ChannelID]*channel
 	activeSessions   map[wtdb.SessionID]wtdb.ClientSession
 	ackedUpdates     map[wtdb.SessionID]map[lnwire.ChannelID]*wtdb.RangeIndex
 	committedUpdates map[wtdb.SessionID][]wtdb.CommittedUpdate
 	towerIndex       map[towerPK]wtdb.TowerID
 	towers           map[wtdb.TowerID]*wtdb.Tower
+	closableSessions map[wtdb.SessionID]uint32
 
 	nextIndex     uint32
 	indexes       map[keyIndexKey]uint32
@@ -39,7 +46,7 @@ type ClientDB struct {
 // NewClientDB initializes a new mock ClientDB.
 func NewClientDB() *ClientDB {
 	return &ClientDB{
-		summaries:        make(map[lnwire.ChannelID]wtdb.ClientChanSummary),
+		channels:         make(map[lnwire.ChannelID]*channel),
 		activeSessions:   make(map[wtdb.SessionID]wtdb.ClientSession),
 		ackedUpdates:     make(map[wtdb.SessionID]map[lnwire.ChannelID]*wtdb.RangeIndex),
 		committedUpdates: make(map[wtdb.SessionID][]wtdb.CommittedUpdate),
@@ -47,6 +54,7 @@ func NewClientDB() *ClientDB {
 		towers:           make(map[wtdb.TowerID]*wtdb.Tower),
 		indexes:          make(map[keyIndexKey]uint32),
 		legacyIndexes:    make(map[wtdb.TowerID]uint32),
+		closableSessions: make(map[wtdb.SessionID]uint32),
 	}
 }
 
@@ -467,6 +475,13 @@ func (m *ClientDB) AckUpdate(id *wtdb.SessionID, seqNum,
 			continue
 		}
 
+		// Add sessionID to channel.
+		channel, ok := m.channels[update.BackupID.ChanID]
+		if !ok {
+			return wtdb.ErrChannelNotRegistered
+		}
+		channel.sessions[*id] = true
+
 		// Remove the committed update from disk and mark the update as
 		// acked. The tower last applied value is also recorded to send
 		// along with the next update.
@@ -494,13 +509,104 @@ func (m *ClientDB) FetchChanSummaries() (wtdb.ChannelSummaries, error) {
 	defer m.mu.Unlock()
 
 	summaries := make(map[lnwire.ChannelID]wtdb.ClientChanSummary)
-	for chanID, summary := range m.summaries {
+	for chanID, channel := range m.channels {
 		summaries[chanID] = wtdb.ClientChanSummary{
-			SweepPkScript: cloneBytes(summary.SweepPkScript),
+			SweepPkScript: cloneBytes(
+				channel.summary.SweepPkScript,
+			),
 		}
 	}
 
 	return summaries, nil
+}
+
+// MarkChannelClosed will mark a registered channel as closed by setting
+// its closed-height as the given block height. It returns a list of
+// session IDs for sessions that are now considered closable due to the
+// close of this channel.
+func (m *ClientDB) MarkChannelClosed(chanID lnwire.ChannelID,
+	blockHeight uint32) ([]wtdb.SessionID, error) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	channel, ok := m.channels[chanID]
+	if !ok {
+		return nil, wtdb.ErrChannelNotRegistered
+	}
+
+	// If there are no sessions for this channel, the channel details can be
+	// deleted.
+	if len(channel.sessions) == 0 {
+		delete(m.channels, chanID)
+		return nil, nil
+	}
+
+	// Mark the channel as closed.
+	channel.closedHeight = blockHeight
+
+	// Now iterate through all the sessions of the channel to check if any
+	// of them are closeable.
+	var closableSessions []wtdb.SessionID
+	for sessID := range channel.sessions {
+		isClosable, err := m.isSessionClosable(sessID)
+		if err != nil {
+			return nil, err
+		}
+
+		if !isClosable {
+			continue
+		}
+
+		closableSessions = append(closableSessions, sessID)
+
+		// Add session to "closableSessions" list and add the block
+		// height that this last channel was closed in. This will be
+		// used in future to determine when we should delete the
+		// session.
+		m.closableSessions[sessID] = blockHeight
+	}
+
+	return closableSessions, nil
+}
+
+// isSessionClosable returns true if a session is considered closable. A session
+// is considered closable only if: 1) It has no un-acked updates, 2) It is
+// exhausted (ie it cant accept any more updates), 3) All the channels that it
+// has acked-updates for are all closed.
+func (m *ClientDB) isSessionClosable(id wtdb.SessionID) (bool, error) {
+	// The session is not closable if it has un-acked updates.
+	if len(m.committedUpdates[id]) > 0 {
+		return false, nil
+	}
+
+	sess, ok := m.activeSessions[id]
+	if !ok {
+		return false, wtdb.ErrClientSessionNotFound
+	}
+
+	// The session is not closable if it is not yet exhausted.
+	if sess.SeqNum != sess.Policy.MaxUpdates {
+		return false, nil
+	}
+
+	// Iterate over each of the channels that the session has acked-updates
+	// for. If any of those channels are not closed, then the session is
+	// not yet closable.
+	for chanID := range m.ackedUpdates[id] {
+		channel, ok := m.channels[chanID]
+		if !ok {
+			continue
+		}
+
+		// Channel is not yet closed, and so we can not yet delete the
+		// session.
+		if channel.closedHeight == 0 {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 // GetClientSession loads the ClientSession with the given ID from the DB.
@@ -544,12 +650,15 @@ func (m *ClientDB) RegisterChannel(chanID lnwire.ChannelID,
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.summaries[chanID]; ok {
+	if _, ok := m.channels[chanID]; ok {
 		return wtdb.ErrChannelAlreadyRegistered
 	}
 
-	m.summaries[chanID] = wtdb.ClientChanSummary{
-		SweepPkScript: cloneBytes(sweepPkScript),
+	m.channels[chanID] = &channel{
+		summary: &wtdb.ClientChanSummary{
+			SweepPkScript: cloneBytes(sweepPkScript),
+		},
+		sessions: make(map[wtdb.SessionID]bool),
 	}
 
 	return nil

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -503,6 +503,36 @@ func (m *ClientDB) FetchChanSummaries() (wtdb.ChannelSummaries, error) {
 	return summaries, nil
 }
 
+// GetClientSession loads the ClientSession with the given ID from the DB.
+func (m *ClientDB) GetClientSession(id wtdb.SessionID,
+	opts ...wtdb.ClientSessionListOption) (*wtdb.ClientSession, error) {
+
+	cfg := wtdb.NewClientSessionCfg()
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	session, ok := m.activeSessions[id]
+	if !ok {
+		return nil, wtdb.ErrClientSessionNotFound
+	}
+
+	if cfg.PerMaxHeight != nil {
+		for chanID, index := range m.ackedUpdates[session.ID] {
+			cfg.PerMaxHeight(&session, chanID, index.MaxHeight())
+		}
+	}
+
+	if cfg.PerCommittedUpdate != nil {
+		for _, update := range m.committedUpdates[session.ID] {
+			update := update
+			cfg.PerCommittedUpdate(&session, &update)
+		}
+	}
+
+	return &session, nil
+}
+
 // RegisterChannel registers a channel for use within the client database. For
 // now, all that is stored in the channel summary is the sweep pkscript that
 // we'd like any tower sweeps to pay into. In the future, this will be extended

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -653,6 +653,31 @@ func (m *ClientDB) GetClientSession(id wtdb.SessionID,
 	return &session, nil
 }
 
+// DeleteSession can be called when a session should be deleted from the DB.
+// All references to the session will also be deleted from the DB.
+func (m *ClientDB) DeleteSession(id wtdb.SessionID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, ok := m.closableSessions[id]
+	if !ok {
+		return wtdb.ErrSessionNotClosable
+	}
+
+	// For each of the channels, delete the session ID entry.
+	for chanID := range m.ackedUpdates[id] {
+		c, ok := m.channels[chanID]
+		if !ok {
+			return wtdb.ErrChannelNotRegistered
+		}
+
+		delete(c.sessions, id)
+	}
+
+	delete(m.closableSessions, id)
+	return nil
+}
+
 // RegisterChannel registers a channel for use within the client database. For
 // now, all that is stored in the channel summary is the sweep pkscript that
 // we'd like any tower sweeps to pay into. In the future, this will be extended


### PR DESCRIPTION
In this PR, we start making use of of the `DeleteSession` message. This message allows a tower client to indicate to a tower server that it can delete sessions. Sessions are considered "deletable" if they are exhausted & if all the acked-updates sent on the session are for channels that are closed. 

This allows us to claim back disk space on both the client and server.

Depends on https://github.com/lightningnetwork/lnd/pull/7055 (So pls ignore the first 10 commits)

Fixes https://github.com/lightningnetwork/lnd/issues/6259

TODO:
- [ ] need to add some tests using the client harness & perhaps also an itest. 

# Main Changes:

## Add a channel -> session ID index:
This is add so that it is quick to check which sessions should be checked if a channel is closed.

## Channel Close handler:
The tower client now subscribes to channel closures. Once a notification is received, it is marked as closed in the tower DB along with the close block height. We then check each of the session that have acked updates for the tower to see if they are closable - if they are, then we add the sessionID to the new `closable sessions` bucket. 

## Closable Sessions handler:
We use a min-heap to store all the closable-sessions.
The tower client now subscribes to new blocks notifications. On each new block, we check the min-heap to see if there are sessions we should close. If there are, then we dial the tower and send the `DeleteSession` message and we also delete all the session info from our DB. 