### PR TITLE
Add context to MarkEdgeZombie

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -3726,7 +3726,7 @@ func (d *AuthenticatedGossiper) ShouldDisconnect(pubkey *btcec.PublicKey) (
 // transaction from chain to ensure that it exists, is not spent and matches
 // the channel announcement proof. The transaction's outpoint and value are
 // returned if we can glean them from the work done in this method.
-func (d *AuthenticatedGossiper) validateFundingTransaction(_ context.Context,
+func (d *AuthenticatedGossiper) validateFundingTransaction(ctx context.Context,
 	ann *lnwire.ChannelAnnouncement1,
 	tapscriptRoot fn.Option[chainhash.Hash]) (wire.OutPoint, btcutil.Amount,
 	[]byte, error) {
@@ -3760,7 +3760,7 @@ func (d *AuthenticatedGossiper) validateFundingTransaction(_ context.Context,
 			// we'll mark the edge itself as a zombie so we don't
 			// continue to request it. We use the "zero key" for
 			// both node pubkeys so this edge can't be resurrected.
-			zErr := d.cfg.Graph.MarkZombieEdge(scid.ToUint64())
+			zErr := d.cfg.Graph.MarkZombieEdge(ctx, scid.ToUint64())
 			if zErr != nil {
 				return wire.OutPoint{}, 0, nil, zErr
 			}
@@ -3798,7 +3798,7 @@ func (d *AuthenticatedGossiper) validateFundingTransaction(_ context.Context,
 	if err != nil {
 		// Mark the edge as a zombie so we won't try to re-validate it
 		// on start up.
-		zErr := d.cfg.Graph.MarkZombieEdge(scid.ToUint64())
+		zErr := d.cfg.Graph.MarkZombieEdge(ctx, scid.ToUint64())
 		if zErr != nil {
 			return wire.OutPoint{}, 0, nil, zErr
 		}
@@ -3815,7 +3815,7 @@ func (d *AuthenticatedGossiper) validateFundingTransaction(_ context.Context,
 	)
 	if err != nil {
 		if errors.Is(err, btcwallet.ErrOutputSpent) {
-			zErr := d.cfg.Graph.MarkZombieEdge(scid.ToUint64())
+			zErr := d.cfg.Graph.MarkZombieEdge(ctx, scid.ToUint64())
 			if zErr != nil {
 				return wire.OutPoint{}, 0, nil, zErr
 			}

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -2412,10 +2412,10 @@ func TestRejectZombieEdge(t *testing.T) {
 	// zombie within the router. This should reject any announcements for
 	// this edge while it remains as a zombie.
 	chanID := batch.chanAnn.ShortChannelID
-	err = tCtx.router.MarkEdgeZombie(
-		ctx,
-		chanID, batch.chanAnn.NodeID1, batch.chanAnn.NodeID2,
-	)
+       err = tCtx.router.MarkEdgeZombie(
+               ctx, chanID,
+               batch.chanAnn.NodeID1, batch.chanAnn.NodeID2,
+       )
 	if err != nil {
 		t.Fatalf("unable to mark channel %v as zombie: %v", chanID, err)
 	}
@@ -2504,10 +2504,10 @@ func TestProcessZombieEdgeNowLive(t *testing.T) {
 	// want to allow a new update from the second node to allow the entire
 	// edge to be resurrected.
 	chanID := batch.chanAnn.ShortChannelID
-	err = tCtx.router.MarkEdgeZombie(
-		ctx,
-		chanID, [33]byte{}, batch.chanAnn.NodeID2,
-	)
+       err = tCtx.router.MarkEdgeZombie(
+               ctx, chanID,
+               [33]byte{}, batch.chanAnn.NodeID2,
+       )
 	if err != nil {
 		t.Fatalf("unable mark channel %v as zombie: %v", chanID, err)
 	}

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -119,9 +119,9 @@ func (r *mockGraphSource) AddNode(_ context.Context, node *models.LightningNode,
 	return nil
 }
 
-func (r *mockGraphSource) MarkZombieEdge(scid uint64) error {
+func (r *mockGraphSource) MarkZombieEdge(ctx context.Context, scid uint64) error {
 	return r.MarkEdgeZombie(
-		lnwire.NewShortChanIDFromInt(scid), [33]byte{}, [33]byte{},
+		ctx, lnwire.NewShortChanIDFromInt(scid), [33]byte{}, [33]byte{},
 	)
 }
 
@@ -414,8 +414,8 @@ func (r *mockGraphSource) MarkEdgeLive(chanID lnwire.ShortChannelID) error {
 }
 
 // MarkEdgeZombie marks an edge as a zombie within our zombie index.
-func (r *mockGraphSource) MarkEdgeZombie(chanID lnwire.ShortChannelID, pubKey1,
-	pubKey2 [33]byte) error {
+func (r *mockGraphSource) MarkEdgeZombie(ctx context.Context,
+	chanID lnwire.ShortChannelID, pubKey1, pubKey2 [33]byte) error {
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -2413,6 +2413,7 @@ func TestRejectZombieEdge(t *testing.T) {
 	// this edge while it remains as a zombie.
 	chanID := batch.chanAnn.ShortChannelID
 	err = tCtx.router.MarkEdgeZombie(
+		ctx,
 		chanID, batch.chanAnn.NodeID1, batch.chanAnn.NodeID2,
 	)
 	if err != nil {
@@ -2504,6 +2505,7 @@ func TestProcessZombieEdgeNowLive(t *testing.T) {
 	// edge to be resurrected.
 	chanID := batch.chanAnn.ShortChannelID
 	err = tCtx.router.MarkEdgeZombie(
+		ctx,
 		chanID, [33]byte{}, batch.chanAnn.NodeID2,
 	)
 	if err != nil {

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -898,12 +898,12 @@ func (b *Builder) assertNodeAnnFreshness(ctx context.Context, node route.Vertex,
 
 // MarkZombieEdge adds a channel that failed complete validation into the zombie
 // index so we can avoid having to re-validate it in the future.
-func (b *Builder) MarkZombieEdge(chanID uint64) error {
+func (b *Builder) MarkZombieEdge(ctx context.Context, chanID uint64) error {
 	// If the edge fails validation we'll mark the edge itself as a zombie
 	// so we don't continue to request it. We use the "zero key" for both
 	// node pubkeys so this edge can't be resurrected.
 	var zeroKey [33]byte
-	err := b.cfg.Graph.MarkEdgeZombie(chanID, zeroKey, zeroKey)
+	err := b.cfg.Graph.MarkEdgeZombie(ctx, chanID, zeroKey, zeroKey)
 	if err != nil {
 		return fmt.Errorf("unable to mark spent chan(id=%v) as a "+
 			"zombie: %w", chanID, err)

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -549,10 +549,10 @@ func (c *ChannelGraph) FilterKnownChanIDs(chansInfo []ChannelUpdateInfo,
 // MarkEdgeZombie attempts to mark a channel identified by its channel ID as a
 // zombie. This method is used on an ad-hoc basis, when channels need to be
 // marked as zombies outside the normal pruning cycle.
-func (c *ChannelGraph) MarkEdgeZombie(chanID uint64,
+func (c *ChannelGraph) MarkEdgeZombie(ctx context.Context, chanID uint64,
 	pubKey1, pubKey2 [33]byte) error {
 
-	err := c.V1Store.MarkEdgeZombie(chanID, pubKey1, pubKey2)
+	err := c.V1Store.MarkEdgeZombie(ctx, chanID, pubKey1, pubKey2)
 	if err != nil {
 		return err
 	}

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -2255,6 +2255,7 @@ func TestNodeUpdatesInHorizon(t *testing.T) {
 // FilterKnownChanIDs is tested in TestFilterKnownChanIDs.
 func TestFilterKnownChanIDsZombieRevival(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	graph := MakeTestGraph(t)
 
@@ -2272,9 +2273,13 @@ func TestFilterKnownChanIDsZombieRevival(t *testing.T) {
 	}
 
 	// Mark channel 1 and 2 as zombies.
-	err := graph.MarkEdgeZombie(scid1.ToUint64(), [33]byte{}, [33]byte{})
+	err := graph.MarkEdgeZombie(
+		ctx, scid1.ToUint64(), [33]byte{}, [33]byte{},
+	)
 	require.NoError(t, err)
-	err = graph.MarkEdgeZombie(scid2.ToUint64(), [33]byte{}, [33]byte{})
+	err = graph.MarkEdgeZombie(
+		ctx, scid2.ToUint64(), [33]byte{}, [33]byte{},
+	)
 	require.NoError(t, err)
 
 	require.True(t, isZombie(scid1))
@@ -2628,6 +2633,7 @@ func TestStressTestChannelGraphAPI(t *testing.T) {
 				}
 
 				return graph.MarkEdgeZombie(
+					ctx,
 					channel.id.ToUint64(),
 					node1.PubKeyBytes,
 					node2.PubKeyBytes,
@@ -3941,6 +3947,7 @@ func TestGraphZombieIndex(t *testing.T) {
 	// If we mark the edge as a zombie manually, then it should show up as
 	// being a zombie once again.
 	err = graph.MarkEdgeZombie(
+		ctx,
 		edge.ChannelID, node1.PubKeyBytes, node2.PubKeyBytes,
 	)
 	require.NoError(t, err, "unable to mark edge as zombie")

--- a/graph/db/interfaces.go
+++ b/graph/db/interfaces.go
@@ -298,7 +298,7 @@ type V1Store interface { //nolint:interfacebloat
 	// MarkEdgeZombie attempts to mark a channel identified by its channel
 	// ID as a zombie. This method is used on an ad-hoc basis, when channels
 	// need to be marked as zombies outside the normal pruning cycle.
-	MarkEdgeZombie(chanID uint64,
+	MarkEdgeZombie(ctx context.Context, chanID uint64,
 		pubKey1, pubKey2 [33]byte) error
 
 	// MarkEdgeLive clears an edge from our zombie index, deeming it as

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -3708,7 +3708,7 @@ func (c *KVStore) ChannelView() ([]EdgePoint, error) {
 // MarkEdgeZombie attempts to mark a channel identified by its channel ID as a
 // zombie. This method is used on an ad-hoc basis, when channels need to be
 // marked as zombies outside the normal pruning cycle.
-func (c *KVStore) MarkEdgeZombie(chanID uint64,
+func (c *KVStore) MarkEdgeZombie(_ context.Context, chanID uint64,
 	pubKey1, pubKey2 [33]byte) error {
 
 	c.cacheMu.Lock()

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -1546,10 +1546,8 @@ func (s *SQLStore) FilterChannelRange(startHeight, endHeight uint32,
 // marked as zombies outside the normal pruning cycle.
 //
 // NOTE: part of the V1Store interface.
-func (s *SQLStore) MarkEdgeZombie(chanID uint64,
+func (s *SQLStore) MarkEdgeZombie(ctx context.Context, chanID uint64,
 	pubKey1, pubKey2 [33]byte) error {
-
-	ctx := context.TODO()
 
 	s.cacheMu.Lock()
 	defer s.cacheMu.Unlock()

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -89,7 +89,7 @@ type ChannelGraphSource interface {
 		route.Vertex) (*models.LightningNode, error)
 
 	// MarkZombieEdge marks the channel with the given ID as a zombie edge.
-	MarkZombieEdge(chanID uint64) error
+	MarkZombieEdge(ctx context.Context, chanID uint64) error
 
 	// IsZombieEdge returns true if the edge with the given channel ID is
 	// currently marked as a zombie edge.
@@ -221,7 +221,8 @@ type DB interface {
 	// MarkEdgeZombie attempts to mark a channel identified by its channel
 	// ID as a zombie. This method is used on an ad-hoc basis, when channels
 	// need to be marked as zombies outside the normal pruning cycle.
-	MarkEdgeZombie(chanID uint64, pubKey1, pubKey2 [33]byte) error
+	MarkEdgeZombie(ctx context.Context, chanID uint64,
+		pubKey1, pubKey2 [33]byte) error
 
 	// UpdateEdgePolicy updates the edge routing policy for a single
 	// directed edge within the database for the referenced channel. The


### PR DESCRIPTION
## Summary
- pass context to `MarkEdgeZombie` calls
- thread context through graph, store, and builder
- update tests for new method signature
- use a shared context variable in tests

## Testing
- `go test ./graph/... ./discovery/...` *(fails: forbidden access to storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_686b869173448323828c1a6af8b5db05